### PR TITLE
update color selection order for bar

### DIFF
--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -68,8 +68,8 @@ define(function(require) {
             chartWidth, chartHeight,
             xScale, yScale,
             colorSchema = colorHelper.colorSchemas.singleColorAloeGreen,
-            colorScale,
-            topicColorMap,
+            colorList,
+            colorMap,
             numOfVerticalTicks = 5,
             numOfHorizontalTicks = 5,
             percentageAxisToMaxRatio = 1,
@@ -103,7 +103,6 @@ define(function(require) {
             // extractors
             getName = ({name}) => name,
             getValue = ({value}) => value,
-            getLineColor = ({topic}) => colorScale(topic),
 
             _percentageLabelHorizontalX = ({value}) => xScale(value) + percentageLabelMargin,
             _percentageLabelHorizontalY= ({name}) => yScale(name) + (yScale.bandwidth() / 2) + (percentageLabelSize * (3/8)),
@@ -207,13 +206,15 @@ define(function(require) {
                     .rangeRound([chartHeight, 0])
                     .padding(0.1);
             }
-            colorScale = d3Scale.scaleOrdinal().range(colorSchema).domain(data.map((_, i) => i))
 
-            let range = colorScale.range();
-            topicColorMap = colorScale.domain().reduce((memo, item, i) => {
-                memo[item] = range[i];
-                return memo;
-            }, {});
+            colorList = data.map(d => d)
+                            .reverse()
+                            .map(({name}, i) => ({
+                                    name,
+                                    color: colorSchema[i % colorSchema.length]}
+                                ));
+
+            colorMap = (item) => colorList.filter(({name}) => name === item)[0].color;
         }
 
         /**
@@ -290,17 +291,17 @@ define(function(require) {
                 .attr('x', 0)
                 .attr('height', yScale.bandwidth())
                 .attr('width', ({value}) => xScale(value))
-                .attr('fill', ({name}) => colorScale(name))
+                .attr('fill', ({name}) => colorMap(name))
                 .on('mouseover', function() {
                     dispatcher.call('customMouseOver', this);
-                    d3Selection.select(this).attr('fill', ({name}) => d3Color.color(colorScale(name)).darker())
+                    d3Selection.select(this).attr('fill', ({name}) => d3Color.color(colorMap(name)).darker());
                 })
                 .on('mousemove', function(d) {
                     dispatcher.call('customMouseMove', this, d, d3Selection.mouse(this), [chartWidth, chartHeight]);
                 })
                 .on('mouseout', function() {
                     dispatcher.call('customMouseOut', this);
-                    d3Selection.select(this).attr('fill', ({name}) => colorScale(name))
+                    d3Selection.select(this).attr('fill', ({name}) => colorMap(name))
                 })
               .merge(bars)
                 .attr('x', 0)
@@ -323,17 +324,17 @@ define(function(require) {
                 .attr('y', ({value}) => yScale(value))
                 .attr('width', xScale.bandwidth())
                 .attr('height', ({value}) => chartHeight - yScale(value))
-                .attr('fill', ({name}) => colorScale(name))
+                .attr('fill', ({name}) => colorMap(name))
                 .on('mouseover', function() {
                     dispatcher.call('customMouseOver', this);
-                    d3Selection.select(this).attr('fill', ({name}) => d3Color.color(colorScale(name)).darker())
+                    d3Selection.select(this).attr('fill', ({name}) => d3Color.color(colorMap(name)).darker())
                 })
                 .on('mousemove', function(d) {
                     dispatcher.call('customMouseMove', this, d, d3Selection.mouse(this), [chartWidth, chartHeight]);
                 })
                 .on('mouseout', function() {
                     dispatcher.call('customMouseOut', this);
-                    d3Selection.select(this).attr('fill', ({name}) => colorScale(name))
+                    d3Selection.select(this).attr('fill', ({name}) => colorMap(name))
                 })
               .merge(bars)
                 .attr('x', ({name}) => xScale(name))

--- a/src/charts/helpers/colors.js
+++ b/src/charts/helpers/colors.js
@@ -10,12 +10,12 @@ define(function(require) {
     // Color Schemas
     // Standard Color Schema for Britecharts
     const britechartsColorSchema = [
-            '#39c2c9',
-            '#ffce00',
-            '#ffa71a',
-            '#f866b9',
-            '#998ce3',
-            '#6aedc7'
+            '#6aedc7', //green
+            '#39c2c9', //blue
+            '#ffce00', //yellow
+            '#ffa71a', //orange
+            '#f866b9', //pink
+            '#998ce3' //purple
         ];
 
     // Grey Schema for Britecharts


### PR DESCRIPTION
Use color map to determine which color to make each horizontal bar

## Description
Have the bar charts use the color map defiened here to determine which color they should fill each bar.
Also, move green to the top of the britecharts color schema, per suns recommendation

## Motivation and Context
Bar chart colorScale was giving us some really weird responses, we want to make sure that the first bar always matches the first color in the color schema. 

## How Has This Been Tested?
All tests pass, visually looks good and in core also works like a charm

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/8100360/23970706/192baeb0-0988-11e7-9945-ea12a9f6e129.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
