### PR TITLE
Fixing css link in demo html

### DIFF
--- a/demos/bar.html
+++ b/demos/bar.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Bar Chart Demo - Britecharts</title>
-    <link type="text/css" rel="stylesheet" href="styles/britecharts.css" />
+    <link type="text/css" rel="stylesheet" href="css/britecharts.css" />
 </head>
 <body id="bar">
     <div class="container">

--- a/demos/brush.html
+++ b/demos/brush.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Brush Chart Demo - Britecharts</title>
-    <link type="text/css" rel="stylesheet" href="styles/britecharts.css" />
+    <link type="text/css" rel="stylesheet" href="css/britecharts.css" />
 
     <style type="text/css">
         .date-range {

--- a/demos/donut.html
+++ b/demos/donut.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Donut Chart Demo - Britecharts</title>
-    <link type="text/css" rel="stylesheet" href="styles/britecharts.css" />
+    <link type="text/css" rel="stylesheet" href="css/britecharts.css" />
     <style type="text/css">
         /*TODO: Do this with Bootstrap*/
         .legend-chart-container {

--- a/demos/kitchen-sink.html
+++ b/demos/kitchen-sink.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <title>Kitchen Sink - Britecharts</title>
-        <link type="text/css" rel="stylesheet" href="styles/britecharts.css" />
+        <link type="text/css" rel="stylesheet" href="css/britecharts.css" />
     </head>
     <body>
         <div class="container">

--- a/demos/line.html
+++ b/demos/line.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Line Chart Demo - Britecharts</title>
-    <link type="text/css" rel="stylesheet" href="styles/britecharts.css" />
+    <link type="text/css" rel="stylesheet" href="css/britecharts.css" />
 </head>
 <body id="line">
     <div class="container">

--- a/demos/sparkline.html
+++ b/demos/sparkline.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Sparkline Chart Demo - Britecharts</title>
-    <link type="text/css" rel="stylesheet" href="styles/britecharts.css" />
+    <link type="text/css" rel="stylesheet" href="css/britecharts.css" />
 </head>
 <body id="sparkline">
     <div class="container">

--- a/demos/stacked-area.html
+++ b/demos/stacked-area.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Stacked Area Chart Demo - Britecharts</title>
-    <link type="text/css" rel="stylesheet" href="styles/britecharts.css" />
+    <link type="text/css" rel="stylesheet" href="css/britecharts.css" />
 </head>
 <body id="stacked-area">
     <div class="container">

--- a/demos/step.html
+++ b/demos/step.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Step Chart Demo - Britecharts</title>
-    <link type="text/css" rel="stylesheet" href="styles/britecharts.css" />
+    <link type="text/css" rel="stylesheet" href="css/britecharts.css" />
 </head>
 <body id="step">
     <div class="container">


### PR DESCRIPTION
## Description
The path in the demos html files were pointing to`/styles` instead of `/css`. I suspect it has to do with how the templates are built and it copying the file structure in `src/` instead of post build. I'm guessing that the demos are built out via a separate build process, and the html is not hard coded, so this is probably a temporary solution until the build config is fixed.

## Motivation and Context
Broken link to css in demos 

## How Has This Been Tested?
Checked that the file path is correct by spinning up a local server `npm run demos:serve` and making sure there was no errors in the network requests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
