### PR TITLE
Demos: only listen for width resize (#206)

### DIFF
--- a/demos/helpers/resizeHelper.js
+++ b/demos/helpers/resizeHelper.js
@@ -2,16 +2,20 @@ define(function(require) {
 
     var _ = require('underscore'),
         d3Selection = require('d3-selection'),
-
         PubSub = require('pubsub-js'),
-
-        debounceDelay = 200;
-
+        debounceDelay = 200,
+        cachedWidth = window.innerWidth;
 
     d3Selection.select(window)
         .on('resize', _.debounce(function(){
-            PubSub.publish('resize');
-        }, debounceDelay));
+                var newWidth = window.innerWidth;
+
+                if (cachedWidth !== newWidth) {
+                    cachedWidth = newWidth;
+                    PubSub.publish('resize');
+                }
+
+            }, debounceDelay));
 
     return {};
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Avoid triggering a resize when viewport height changes on the demos.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Undesired rerender on mobile browsers when scrolling, see #206 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Android, Samsung S7 + Chrome

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
