### PR TITLE
Eventbrite copyright message now appears on bottom of docs pages when printed

### DIFF
--- a/docs/styles/demos.css
+++ b/docs/styles/demos.css
@@ -43,6 +43,7 @@
         position: fixed;
     }
 }
+
 /* Copyright */
 .copyright {
     font-size: 80%;

--- a/docs/styles/demos.css
+++ b/docs/styles/demos.css
@@ -37,6 +37,12 @@
     background-color: white;
     padding: 10px;
 }
+@media print
+{
+    .footer {
+        position: fixed;
+    }
+}
 /* Copyright */
 .copyright {
     font-size: 80%;

--- a/src/doc/template/static/styles/demos.css
+++ b/src/doc/template/static/styles/demos.css
@@ -39,7 +39,7 @@
 }
 @media print
 {
-    .footer, .footer * {
+    .footer {
         position: fixed;
     }
 }

--- a/src/doc/template/static/styles/demos.css
+++ b/src/doc/template/static/styles/demos.css
@@ -37,6 +37,13 @@
     background-color: white;
     padding: 10px;
 }
+@media print
+{
+    .footer, .footer * {
+        position: fixed;
+    }
+}
+
 /* Copyright */
 .copyright {
     font-size: 80%;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously "Eventbrite Copyright" would appear in the middle of the page overlaid on other elements when a docs page was printed.  Now the page appears on the bottom on Chrome and Firefox and doesn't appear on Safari. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fix addresses #228. Also just saw Marcos submitted a PR for this already :(. I'm not sure it's better to just hide it, when we could put it on the bottom of the page so it reflects the webpage as much as possible like the poster in #228 said. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built the docs and tested on Chrome, Safari, and Firefox with Mac OSX 10.11.6. 

This change doesn't seem to affect other areas of the code besides the built css after the docs are built.

## Screenshots (if appropriate):
Before:
<img width="778" alt="screen shot 2017-05-15 at 10 53 00 pm" src="https://cloud.githubusercontent.com/assets/1953194/26080841/af743f90-399e-11e7-9d77-5ae6b9232be1.png">

After:
<img width="778" alt="screen shot 2017-05-15 at 10 53 00 pm" src="https://cloud.githubusercontent.com/assets/8570077/26089992/77fc65dc-39c7-11e7-8fa7-d53670d1c85b.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
