### PR TITLE
[Windows] Fix the "run" scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,20 +18,20 @@
     }
   ],
   "scripts": {
-    "demos:compile": "WEBPACK_ENV=demos webpack --progress --colors",
-    "demos:watch": "WEBPACK_ENV=demos webpack --watch --progress --colors",
-    "demos:serve": "WEBPACK_ENV=demos webpack-dev-server --inline --hot --port 8001",
+    "demos:compile": "webpack --progress --colors --mode=demos",
+    "demos:watch": "webpack --watch --progress --colors --mode=demos",
+    "demos:serve": "webpack-dev-server --inline --hot --port 8001 --mode=demos",
     "styles": "grunt lint && grunt sass && grunt cssmin",
-    "docs": "WEBPACK_ENV=demos webpack && npm run styles && grunt docs",
+    "docs": "webpack --mode=demos && npm run styles && grunt docs",
     "prod": "npm run _prodUMD && npm run _prod",
     "untrack": "grunt untrack",
     "release": "npm run prod && grunt release:patch",
     "release:minor": "npm run prod && grunt release:minor",
     "release:major": "npm run prod && grunt release:major",
-    "test": "WEBPACK_ENV=test karma start",
-    "test:travis": "WEBPACK_ENV=test karma start --single-run --browsers PhantomJS",
-    "_prod": "WEBPACK_ENV=prod webpack",
-    "_prodUMD": "WEBPACK_ENV=prodUMD webpack",
+    "test": "karma start --mode=test",
+    "test:travis": "karma start --single-run --browsers PhantomJS --mode=test",
+    "_prod": "webpack --mode=prod",
+    "_prodUMD": "webpack --mode=prodUMD",
     "move": "grunt moveDemos",
     "watch": "grunt watch"
   },
@@ -110,6 +110,7 @@
     "webpack": "^1.13.3",
     "webpack-bundle-analyzer": "^2.3.1",
     "webpack-dev-server": "^1.16.2",
-    "webpack-livereload-plugin": "^0.9.0"
+    "webpack-livereload-plugin": "^0.9.0",
+    "yargs": "^8.0.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ var webpack = require('webpack'),
     UglifyJsPlugin = webpack.optimize.UglifyJsPlugin,
     BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin,
 
-    env = process.env.WEBPACK_ENV, // dev | build
+    env = require('yargs').argv.mode,
     isProduction = env === 'prod' || env === 'prodUMD',
 
     chartModulesPath = path.resolve('./src/charts'),


### PR DESCRIPTION
## Description
Send arguments to the executed command instead of setting environment variables to control configure webpack.

## Motivation and Context
Environment variables aren't handled the same way on Windows and Unix/Linux

Fixes #238

## How Has This Been Tested?
Manually tested by running the scripts on my Windows 10 laptop

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
