### PR TITLE
Feature highlight biggest slice

### DIFF
--- a/demos/demo-donut.js
+++ b/demos/demo-donut.js
@@ -122,16 +122,38 @@ function createSmallDonutChart() {
     }
 }
 
+function createDonutWithHighlightSliceChart() {
+    var donutChart = donut(),
+        donutContainer = d3Selection.select('.js-donut-highlight-slice-chart-container'),
+        containerWidth = donutContainer.node() ? donutContainer.node().getBoundingClientRect().width : false,
+        dataset = new dataBuilder.DonutDataBuilder()
+            .withThreeCategories()
+            .build();
+
+    if (containerWidth) {
+        donutChart
+            .highlightSliceById(1)
+            .width(containerWidth)
+            .height(containerWidth/1.8)
+            .externalRadius(containerWidth/5)
+            .internalRadius(containerWidth/10);
+
+        donutContainer.datum(dataset).call(donutChart);
+    }
+}
+
 // Show charts if container available
 if (d3Selection.select('.js-donut-chart-container').node()) {
     createDonutChart(dataset);
     createSmallDonutChart();
+    createDonutWithHighlightSliceChart();
 
     var redrawCharts = function(){
         d3Selection.selectAll('.donut-chart').remove();
 
         createDonutChart(dataset);
         createSmallDonutChart();
+        createDonutWithHighlightSliceChart();
     };
 
     // Redraw charts on window resize

--- a/demos/donut.html
+++ b/demos/donut.html
@@ -99,5 +99,35 @@ donutContainer.datum(dataset).call(donutChart);
             </div>
         </div>
     </div>
+    <div class="container">
+        <div class="row">
+            <div class="
+col-md-6">
+                <section>
+                    <article>
+                        <h2>Donut Chart and higlight the selected slice</h2>
+                        <div class="js-donut-highlight-slice-chart-container card--chart"></div>
+                    </article>
+                </section>
+            </div>
+            <div class="
+col-md-6 sidebar">
+                <h3>The code    </h3>
+                <pre><code class="language-javascript">
+donutChart
+    .highlightSliceById(1)
+    .width(containerWidth)
+    .height(containerWidth/1.8)
+    .externalRadius(containerWidth/5)
+    .internalRadius(containerWidth/10);
+
+donutContainer.datum(dataset).call(donutChart);
+                </code></pre>
+
+                <h4>Demo Code</h4>
+                <p>Read the whole code of this demo <a href="https://github.com/eventbrite/britecharts/blob/master/demos/demo-donut.js">in github</a></p>
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -292,7 +292,9 @@ define(function(require){
          * @private
          */
         function initHighlightSlice() {
-            if (!highlightedSliceId && highlightedSliceId !== 0) return;
+            if (highlightedSliceId === null || typeof highlightedSliceId === 'undefined') {
+                return;
+            }
 
             highlightedSlice = svg.selectAll('.chart-group .arc path')
                 .select(function(a) {
@@ -301,10 +303,10 @@ define(function(require){
                     }
                 }).node();
 
-            if (!highlightedSlice) return;
-
-            drawLegend(highlightedSlice.__data__);
-            tweenGrowth(highlightedSlice, externalRadius, pieDrawingTransitionDuration);
+            if (highlightedSlice) {
+                drawLegend(highlightedSlice.__data__);
+                tweenGrowth(highlightedSlice, externalRadius, pieDrawingTransitionDuration);
+            }
         }
 
         function handleMouseOver(datum) {

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -127,6 +127,18 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                 expect(defaultSchema).not.toBe(testSchema);
                 expect(newSchema).toBe(testSchema);
             });
+
+            it('should provide a highlightSliceById getter and setter', () => {
+                let defaultId = donutChart.highlightSliceById(),
+                    testId = 10,
+                    newId;
+
+                donutChart.highlightSliceById(testId);
+                newId = donutChart.highlightSliceById();
+
+                expect(defaultId).not.toBe(newId);
+                expect(newId).toBe(testId);
+            });
         });
 
         describe('when mouse events are triggered', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
By default the donut doesn't have any slice `highlighted`. This feature add the possibility to highlight by default the biggest slice. Like that there is always a value displayed in the donut.

I'm not very happy with the naming, if you have some idea feel free to tell me.

## Motivation and Context
Personnal need :) 

Todo:
- [ ] Generate demos && documentation
- [ ] Generate UMD

## Screenshots (if appropriate):
Default with the mouse out of the donut:
![capture du 2017-05-18 21-20-52](https://cloud.githubusercontent.com/assets/860533/26219680/242165d4-3c10-11e7-8d56-409d698c9f7a.png)

When the mouse is over an other slice:
![capture du 2017-05-18 21-21-11](https://cloud.githubusercontent.com/assets/860533/26219708/3b7883c0-3c10-11e7-8fd9-556c82e73e53.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
