### PR TITLE
safety check for Intl in tooltip

### DIFF
--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -376,7 +376,7 @@ define(function(require){
                 localeOptions.hour = 'numeric';
             }
 
-            if (locale) {
+            if (locale && ((typeof Intl !== 'undefined') && (typeof Intl === 'object' && Intl.DateTimeFormat))) {
                 let f = Intl.DateTimeFormat(locale, localeOptions);
 
                 return f.format(date);


### PR DESCRIPTION
Safety check in tooltip to ensure Intl exists before trying to localize

## Description
There was a check on the time axis but not on the tooltip, causing errors in safari

## Motivation and Context
bug fix

## How Has This Been Tested?
run tests, ran in safari

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
