### PR TITLE
fix tooltip format rounding hundreds

### DIFF
--- a/src/charts/helpers/formatHelpers.js
+++ b/src/charts/helpers/formatHelpers.js
@@ -5,7 +5,7 @@ define(function(require) {
 
     const valueRangeLimits = {
                 small: 10,
-                medium: 100
+                medium: 1000
             };
     const integerValueFormats = {
                 small: d3Format.format(''),

--- a/src/charts/helpers/formatHelpers.js
+++ b/src/charts/helpers/formatHelpers.js
@@ -3,27 +3,41 @@ define(function(require) {
 
     const d3Format = require('d3-format');
 
-    const valueRangeLimits = {
-                small: 10,
-                medium: 1000
-            };
     const integerValueFormats = {
-                small: d3Format.format(''),
-                medium: d3Format.format(''),
-                large: d3Format.format('.2s')
+                small: {
+                    limit: 10,
+                    format: d3Format.format('')
+                },
+                medium: {
+                    limit: 1000,
+                    format: d3Format.format('')
+                },
+                large: {
+                    limit: null,
+                    format: d3Format.format('.2s')
+                }
             };
     const decimalValueFormats = {
-                small: d3Format.format('.3f'),
-                medium: d3Format.format('.1f'),
-                large: d3Format.format('.2s')
+                small: {
+                    limit: 10,
+                    format: d3Format.format('.3f')
+                },
+                medium: {
+                    limit: 100,
+                    format: d3Format.format('.1f')
+                },
+                large: {
+                    limit: null,
+                    format: d3Format.format('.2s')
+                }
             };
 
-    function getValueSize(value){
+    function getValueSize(value, limits) {
         let size = 'large';
 
-        if (value < valueRangeLimits.small) {
+        if (value < limits.small.limit) {
             size = 'small';
-        } else if (value < valueRangeLimits.medium) {
+        } else if (value < limits.medium.limit) {
             size = 'medium';
         }
         return size;
@@ -35,7 +49,8 @@ define(function(require) {
      * @return {Number}       Formatted value to show
      */
     function formatIntegerValue(value) {
-        let format = integerValueFormats[getValueSize(value)];
+        let size = getValueSize(value, integerValueFormats);
+        let format = integerValueFormats[size].format;
 
         return format(value);
     }
@@ -46,7 +61,8 @@ define(function(require) {
      * @return {Number}       Formatted value to show
      */
     function formatDecimalValue(value) {
-        let format = decimalValueFormats[getValueSize(value)];
+        let size = getValueSize(value, decimalValueFormats);
+        let format = decimalValueFormats[size].format;
 
         return format(value);
     }

--- a/test/specs/tooltip.spec.js
+++ b/test/specs/tooltip.spec.js
@@ -212,7 +212,6 @@ define(['jquery', 'd3', 'tooltip'], function($, d3, tooltip) {
                             }
                         ]
                     }, topicColorMap, 0);
-
                     actual = containerFixture.select('.britechart-tooltip .tooltip-right-text')
                                 .text()
 
@@ -265,7 +264,7 @@ define(['jquery', 'd3', 'tooltip'], function($, d3, tooltip) {
                 });
 
                 it('should not format medium numbers', () =>  {
-                    var expected = '100',
+                    var expected = '103',
                         actual;
 
                     tooltipChart.update({
@@ -273,7 +272,7 @@ define(['jquery', 'd3', 'tooltip'], function($, d3, tooltip) {
                         topics: [
                             {
                                 name: 103,
-                                value: 100,
+                                value: 103,
                                 topicName: 'San Francisco'
                             }
                         ]


### PR DESCRIPTION
The tooltip format should show precise units until it gets to 1000 (1k, 2k, ...nk) and not for 100

## Description
extend the range to which we use a precise format

## Motivation and Context
When hovering over a number, lets say 123 for example, before, the tooltip would show 120. This is unintuitive and I would say wrong. 

## How Has This Been Tested?
plugged it in!

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/18017479/28190545-4c8c1054-67e0-11e7-8ee3-ea41871b9f30.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
