### PR TITLE
[Issue 268] support custom formatting of tooltip values

### DIFF
--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -69,6 +69,7 @@ define(function(require){
             height = 45,
 
             title = 'Tooltip title',
+            formatFunction = null,
 
             // tooltip
             tooltip,
@@ -238,7 +239,10 @@ define(function(require){
                 return 0;
             }
 
-            if (isInteger(value)) {
+            if( formatFunction ) {
+                value = formatFunction(value);
+            }
+            else if (isInteger(value)) {
                 value = formatIntegerValue(value);
             } else {
                 value = formatDecimalValue(value);

--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -647,6 +647,21 @@ define(function(require){
         };
 
         /**
+         * Gets or Sets the title of the tooltip
+         * @param  {string} _x Desired title
+         * @return { string | module} Current title or module to chain calls
+         * @public
+         */
+        exports.formatFunction = function(_x) {
+            if (!arguments.length) {
+                return formatFunction;
+            }
+            formatFunction = _x;
+
+            return this;
+        };
+
+        /**
          * Pass an override for the ordering of your tooltip
          * @param  {Object[]} _x    Array of the names of your tooltip items
          * @return { overrideOrder | module} Current overrideOrder or Chart module to chain calls

--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -647,9 +647,9 @@ define(function(require){
         };
 
         /**
-         * Gets or Sets the title of the tooltip
-         * @param  {string} _x Desired title
-         * @return { string | module} Current title or module to chain calls
+         * Gets or Sets the formatFunction of the tooltip
+         * @param  {Function} _x Desired formatFunction
+         * @return { Function | module} Current formatFunction or module to chain calls
          * @public
          */
         exports.formatFunction = function(_x) {

--- a/test/specs/tooltip.spec.js
+++ b/test/specs/tooltip.spec.js
@@ -305,6 +305,31 @@ define(['jquery', 'd3', 'tooltip'], function($, d3, tooltip) {
                     expect(actual).toEqual(expected);
                 });
             });
+
+            describe('override default formatting', function() {
+
+                it('should respect format override', () =>  {
+                    var expected = '10,000',
+                        actual;
+
+                    tooltipChart.update({
+                        date: '2015-08-05T07:00:00.000Z',
+                        formatFunction: d3.format(','),
+                        topics: [
+                            {
+                                name: 103,
+                                value: 10000,
+                                topicName: 'San Francisco'
+                            }
+                        ]
+                    }, topicColorMap, 0);
+
+                    actual = containerFixture.select('.britechart-tooltip .tooltip-right-text')
+                        .text()
+
+                    expect(actual).toEqual(expected);
+                });
+            });
         });
 
         describe('API', function() {

--- a/test/specs/tooltip.spec.js
+++ b/test/specs/tooltip.spec.js
@@ -312,9 +312,10 @@ define(['jquery', 'd3', 'tooltip'], function($, d3, tooltip) {
                     var expected = '10,000',
                         actual;
 
+                    tooltipChart.formatFunction(d3.format(','));
+
                     tooltipChart.update({
                         date: '2015-08-05T07:00:00.000Z',
-                        formatFunction: d3.format(','),
                         topics: [
                             {
                                 name: 103,


### PR DESCRIPTION
## Description
Add a format function to the Tooltip module for easy customization

## Motivation and Context
I need this for the Britecharts to be usable for me.  Others want this too: https://github.com/eventbrite/britecharts/issues/268

There are many times where the default formatting (especially of large numbers) is too limiting.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I am running the patched version in my current environment (see screenshot).  This feature is critical for me.

## Screenshots (if appropriate):
<img width="1117" alt="screenshot 2017-07-16 19 24 11" src="https://user-images.githubusercontent.com/1183747/28252644-7eee05f6-6a5c-11e7-9b12-8b2c497cad68.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
