### PR TITLE
Fixes typo in line chart demo

### DIFF
--- a/demos/line.html
+++ b/demos/line.html
@@ -12,7 +12,7 @@
             <div class="col-md-4 sidebar">
                 <h3>The code</h3>
                 <pre><code class="language-javascript">
-lineChart1
+lineChart
     .isAnimated(true)
     .aspectRatio(0.5)
     .grid('horizontal')


### PR DESCRIPTION
## Description
I noticed a typo on the line chart demo page while playing with the examples, which caused a few seconds of confusion. I just though I might as well fix it 😃.

## Motivation and Context
This patch is just to make the examples more consistent and to avoid confusion when new users copy and paste the shown demo code.

## How Has This Been Tested?
I didn’t perform any testing, as this is just a typo in an HTML page. I hope this is fine with you.

## Screenshots (if appropriate):
![screenshot-typo](https://user-images.githubusercontent.com/3244280/28921210-4bc9edb4-7855-11e7-9a07-3721f43ebc89.jpg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.