### PR TITLE
Base tick number calculation on difference between minDate and maxDate instead of array length

### DIFF
--- a/src/charts/helpers/timeAxis.js
+++ b/src/charts/helpers/timeAxis.js
@@ -86,6 +86,13 @@ define(function(require) {
     }
 
     /**
+     * Takes a number representing milliseconds and convert to days
+     * @param  {Number} milliseconds    Any number
+     * @return {Number}                 Number of days that the input represents
+     */
+    const convertMillisecondsToDays = (milliseconds) => Math.ceil(milliseconds/(24*60*60*1000));
+
+    /**
      * Returns tick object to be used when building the x axis
      * @param {dataByDate} dataByDate       Chart data ordered by Date
      * @param {Number} width                Chart width
@@ -108,7 +115,7 @@ define(function(require) {
         let [minor, major] = settings.split('-');
 
         let majorTickValue = settingsToMajorTickMap[settings];
-        let minorTickValue = getMaxNumOfHorizontalTicks(width, dataByDate.length);
+        let minorTickValue = getMaxNumOfHorizontalTicks(width, convertMillisecondsToDays(dateTimeSpan));
 
         return {
             minor: {

--- a/test/specs/helpers.spec.js
+++ b/test/specs/helpers.spec.js
@@ -242,7 +242,7 @@ define([
                     });
 
                     it('should give back a minor hour format and 5 ticks', () => {
-                        expect(minor.tick).toEqual(5);
+                        expect(typeof minor.tick).toEqual('function');
                         expect(minor.format.toString()).toEqual(hourFormat);
                     });
 
@@ -296,7 +296,7 @@ define([
                     });
 
                     it('should give back a minor minute format and 5 ticks', () => {
-                        expect(minor.tick).toEqual(5);
+                        expect(typeof minor.tick).toEqual('function');
                         expect(minor.format.toString()).toEqual(minuteFormat);
                     });
 
@@ -313,7 +313,7 @@ define([
                     });
 
                     it('should give back a minor hour format and 5 ticks', () => {
-                        expect(minor.tick).toEqual(5);
+                        expect(typeof minor.tick).toEqual('function');
                         expect(minor.format.toString()).toEqual(hourFormat);
                     });
 
@@ -330,7 +330,7 @@ define([
                     });
 
                     it('should give back a minor day format and 5 ticks', () => {
-                        expect(minor.tick).toEqual(5);
+                        expect(typeof minor.tick).toEqual('function');
                         expect(minor.format.toString()).toEqual(dayFormat);
                     });
 
@@ -347,7 +347,7 @@ define([
                     });
 
                     it('should give back a minor day format and 5 ticks', () => {
-                        expect(minor.tick).toEqual(5);
+                        expect(typeof minor.tick).toEqual('function');
                         expect(minor.format.toString()).toEqual(monthFormat);
                     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The tick calculation doesn't work well when you have data that skips days, since it is based on array length rather than the difference in days between the minDate and maxDate.

For example, I have a data set that spans from Jan 5 to Feb 6, but there are lots of "holes" in the data so we only have 12 "days" within that range that have data attached.

However it's actually 32 days, but the tick count function believes it's 12 days, causing way too many ticks to be rendered.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change unit tests
## Screenshots (if appropriate):

**Before fix:**
![screen shot 2017-10-26 at 12 04 18 pm](https://user-images.githubusercontent.com/31455015/32073181-0a931640-ba4a-11e7-902b-afda45a7a4f6.png)
small screen:
![screen shot 2017-10-26 at 12 35 05 pm](https://user-images.githubusercontent.com/31455015/32073238-3a4c1102-ba4a-11e7-8340-84aea06f215c.png)

**After fix:**
![screen shot 2017-10-26 at 12 02 32 pm](https://user-images.githubusercontent.com/31455015/32073185-1025f83e-ba4a-11e7-99cb-5c54f57af3e0.png)
small screen:
![screen shot 2017-10-26 at 12 03 06 pm](https://user-images.githubusercontent.com/31455015/32073209-21ccc572-ba4a-11e7-8d92-5121d5779a1a.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
