### PR TITLE
Adds glow on 'active' state to the highlight points in Line and Area charts

### DIFF
--- a/src/charts/helpers/filters.js
+++ b/src/charts/helpers/filters.js
@@ -50,6 +50,40 @@ define(function (require) {
             .attr('in', 'glow');
 
         return filterId;
+    };
+
+    const createGlowWithMatrix = (filterSelector) => {
+        let colorMatrix = '0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0';
+
+        filterSelector
+            .attr('x', '-500%')
+            .attr('y', '-500%')
+            .attr('width', '1800%')
+            .attr('height', '1800%');
+
+        filterSelector
+          .append('feColorMatrix')
+            .attr('type', 'matrix')
+            .attr('values', colorMatrix);
+
+        filterSelector
+          .append('feGaussianBlur')
+            .attr('stdDeviation', '1')
+            .attr('result', 'coloredBlur')
+            .attr('in', 'SourceGraphic');
+
+        let merge = filterSelector
+          .append('feMerge');
+
+        merge
+          .append('feMergeNode')
+            .attr('in', 'coloredBlur');
+
+        merge
+          .append('feMergeNode')
+            .attr('in', 'SourceGraphic');
+
+        return filterId;
     }
 
     const createWhiteGlow = (filterSelector) => {
@@ -104,5 +138,6 @@ define(function (require) {
         createGausianBlur,
         createWhiteGlow,
         createGlow,
+        createGlowWithMatrix,
     };
 });

--- a/src/charts/helpers/filters.js
+++ b/src/charts/helpers/filters.js
@@ -1,0 +1,108 @@
+define(function (require) {
+
+    const d3Selection = require('d3-selection');
+    const filterId = 'highlight-filter';
+
+
+    const createFilterContainer = (metadataSelection) => {
+        let highlightFilter = metadataSelection
+          .append('defs')
+            .append('filter')
+            .attr('id', filterId);
+        
+        return highlightFilter;
+    };
+
+    const createGausianBlur = (filterSelector) => {
+        filterSelector
+          .append('feGaussianBlur')
+            .attr('stdDeviation', 1)
+            .attr('result', 'coloredBlur');
+
+        return filterId;
+    };
+
+    const createGlow = (filterSelector) => {
+        filterSelector
+            .attr('x', '-30%')
+            .attr('y', '-30%')
+            .attr('width', '160%')
+            .attr('height', '160%');
+
+        filterSelector
+          .append('feGaussianBlur')
+            .attr('stdDeviation', '0.9 0.9')
+            .attr('result', 'glow');
+
+        let merge = filterSelector
+          .append('feMerge');
+
+        merge
+          .append('feMergeNode')
+            .attr('in', 'glow');
+
+        merge
+          .append('feMergeNode')
+            .attr('in', 'glow');
+
+        merge
+          .append('feMergeNode')
+            .attr('in', 'glow');
+
+        return filterId;
+    }
+
+    const createWhiteGlow = (filterSelector) => {
+        filterSelector
+            .attr('x', '-5000%')
+            .attr('y', '-5000%')
+            .attr('width', '10000%')
+            .attr('height', '10000%');
+
+        filterSelector
+          .append('feFlood')
+            .attr('result', 'flood')
+            .attr('flood-color', '#ffffff')
+            .attr('flood-opacity', '1');
+
+        filterSelector
+          .append('feComposite')
+            .attr('result', 'mask')
+            .attr('in2', 'SourceGraphic')
+            .attr('operator', 'in')
+            .attr('in', 'flood');
+
+        filterSelector
+          .append('feMorphology')
+            .attr('result', 'dilated')
+            .attr('operator', 'dilate')
+            .attr('radius', '2')
+            .attr('in', 'mask');
+        
+        filterSelector
+          .append('feGaussianBlur')
+            .attr('result', 'blurred')
+            .attr('stdDeviation', '5')
+            .attr('in', 'dilated');
+
+        let merge = filterSelector
+          .append('feMerge');
+
+        merge
+          .append('feMergeNode')
+            .attr('in', 'blurred');
+        
+        merge 
+          .append('feMergeNode')
+            .attr('in', 'SourceGraphic');
+
+        return filterId;
+    };
+
+    return {
+        createFilterContainer,
+        createGausianBlur,
+        createWhiteGlow,
+        createGlow,
+    };
+});

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -14,20 +14,23 @@ define(function(require){
 
     const {exportChart} = require('./helpers/exportChart');
     const colorHelper = require('./helpers/colors');
-    const {isInteger} = require('./helpers/common');
     const {
         getXAxisSettings,
         getLocaleDateFormatter
     } = require('./helpers/timeAxis');
-
     const { axisTimeCombinations } = require('./helpers/constants');
-
-    const { uniqueId } = require('./helpers/common');
-
+    const {
+        createFilterContainer,
+        createGlow,
+    } = require('./helpers/filters');
     const {
         formatIntegerValue,
         formatDecimalValue,
     } = require('./helpers/formatHelpers');
+    const { 
+        isInteger,
+        uniqueId
+    } = require('./helpers/common');
 
     /**
      * @typedef D3Selection
@@ -139,14 +142,18 @@ define(function(require){
             },
             monthAxisPadding = 28,
             tickPadding = 5,
-            highlightCircleSize = 12,
-            highlightCircleStroke = 2,
             colorSchema = colorHelper.colorSchemas.britecharts,
             singleLineGradientColors = colorHelper.colorGradients.greenBlue,
             topicColorMap,
             linearGradient,
             lineGradientId = uniqueId('one-line-gradient'),
 
+            highlightFilter = null,
+            highlightFilterId = null,
+            highlightCircleSize = 12,
+            highlightCircleRadius = 5,
+            highlightCircleStroke = 2,
+            
             xAxisFormat = null,
             xTicks = null,
             xAxisCustomFormat = null,
@@ -241,6 +248,21 @@ define(function(require){
                     addMouseEvents();
                 }
             });
+        }
+
+        /**
+         * Adds a filter to the element
+         * @param {DOMElement} el 
+         * @private
+         */
+        function addGlowFilter(el) {
+            if (!highlightFilter) {
+                highlightFilter = createFilterContainer(svg.select('.metadata-group'));
+                highlightFilterId = createGlow(highlightFilter);
+            }
+
+            d3Selection.select(el)
+                .attr('filter', `url(#${highlightFilterId})`);
         }
 
         /**
@@ -824,12 +846,17 @@ define(function(require){
                                     .classed('data-point-highlighter', true)
                                     .attr('cx', highlightCircleSize)
                                     .attr('cy', 0)
-                                    .attr('r', 5)
+                                    .attr('r', highlightCircleRadius)
                                     .style('stroke-width', highlightCircleStroke)
                                     .style('stroke', topicColorMap[d.name])
-                                    .on('touchstart click', function() {
+                                    .on('click', function () {
+                                        addGlowFilter(this);
                                         handleHighlightClick(this, d);
+                                    })
+                                    .on('mouseout', function () {
+                                        removeFilter(this);
                                     });
+
 
                 const path = topicsWithNode[index].node;
                 const x = xScale(new Date(dataPoint.topics[index].date));
@@ -892,6 +919,15 @@ define(function(require){
          */
         function moveVerticalMarker(verticalMarkerXPosition){
             verticalMarkerContainer.attr('transform', `translate(${verticalMarkerXPosition},0)`);
+        }
+
+        /**
+         * Resets a point filter
+         * @param {DOMElement} point  Point to reset
+         */
+        function removeFilter(point) {
+            d3Selection.select(point)
+                .attr('filter', 'none');
         }
 
         /**

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -21,7 +21,7 @@ define(function(require){
     const { axisTimeCombinations } = require('./helpers/constants');
     const {
         createFilterContainer,
-        createGlow,
+        createGlowWithMatrix,
     } = require('./helpers/filters');
     const {
         formatIntegerValue,
@@ -153,7 +153,10 @@ define(function(require){
             highlightCircleSize = 12,
             highlightCircleRadius = 5,
             highlightCircleStroke = 2,
-            
+            highlightCircleActiveRadius = highlightCircleRadius + 2,
+            highlightCircleActiveStrokeWidth = 5,
+            highlightCircleActiveStrokeOpacity = 0.6,     
+
             xAxisFormat = null,
             xTicks = null,
             xAxisCustomFormat = null,
@@ -258,10 +261,13 @@ define(function(require){
         function addGlowFilter(el) {
             if (!highlightFilter) {
                 highlightFilter = createFilterContainer(svg.select('.metadata-group'));
-                highlightFilterId = createGlow(highlightFilter);
+                highlightFilterId = createGlowWithMatrix(highlightFilter);
             }
 
             d3Selection.select(el)
+                .style('stroke-width', highlightCircleActiveStrokeWidth)
+                .style('r', highlightCircleActiveRadius)
+                .style('stroke-opacity', highlightCircleActiveStrokeOpacity)
                 .attr('filter', `url(#${highlightFilterId})`);
         }
 
@@ -849,6 +855,7 @@ define(function(require){
                                     .attr('r', highlightCircleRadius)
                                     .style('stroke-width', highlightCircleStroke)
                                     .style('stroke', topicColorMap[d.name])
+                                    .style('cursor', 'pointer')
                                     .on('click', function () {
                                         addGlowFilter(this);
                                         handleHighlightClick(this, d);

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -26,7 +26,7 @@ define(function(require){
     } = require('./helpers/formatHelpers');
     const {
         createFilterContainer,
-        createGlow,
+        createGlowWithMatrix,
     } = require('./helpers/filters');
     const {
         isInteger,
@@ -111,7 +111,10 @@ define(function(require){
             highlightFilterId = null,
             highlightCircleSize = 12,
             highlightCircleRadius = 5,
-            highlightCircleStroke = 2,            
+            highlightCircleStroke = 1.2,
+            highlightCircleActiveRadius = highlightCircleRadius + 2,       
+            highlightCircleActiveStrokeWidth = 5, 
+            highlightCircleActiveStrokeOpacity = 0.6,     
             
             areaOpacity = 0.24,
             categoryColorMap,
@@ -226,10 +229,13 @@ define(function(require){
         function addGlowFilter(el) {
             if (!highlightFilter) {
                 highlightFilter = createFilterContainer(svg.select('.metadata-group'));
-                highlightFilterId = createGlow(highlightFilter);
+                highlightFilterId = createGlowWithMatrix(highlightFilter);
             }
 
             d3Selection.select(el)
+                .style('stroke-width', highlightCircleActiveStrokeWidth)
+                .style('r', highlightCircleActiveRadius)
+                .style('stroke-opacity', highlightCircleActiveStrokeOpacity)
                 .attr('filter', `url(#${highlightFilterId})`);
         }
 
@@ -971,6 +977,7 @@ define(function(require){
                         .attr('r', highlightCircleRadius)
                         .style('stroke-width', highlightCircleStroke)
                         .style('stroke', categoryColorMap[d.name])
+                        .style('cursor', 'pointer')
                         .on('click', function() {
                             addGlowFilter(this);
                             handleHighlightClick(this, d);

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -104,6 +104,8 @@ define(function(require){
 
             colorSchema = colorHelper.colorSchemas.britecharts,
             lineGradient = colorHelper.colorGradients.greenBlue,
+            highlightFilter = null,
+            highlightFilterId = 'highlight-filter',
 
             areaOpacity = 0.24,
             highlightCircleSize = 12,
@@ -950,14 +952,77 @@ define(function(require){
                                     .attr('r', highlightCircleRadius)
                                     .style('stroke-width', highlightCircleStroke)
                                     .style('stroke', categoryColorMap[d.name])
-                                    .on('touchstart click', function() {
+                                    .on('click', function() {
+                                        blurPoint(this);
                                         handleHighlightClick(this, d);
+                                    })
+                                    .on('mouseout', function() {
+                                        unBlurPoint(this);
                                     });
 
                 accumulator = accumulator + values[index][valueLabel];
 
                 marker.attr('transform', `translate( ${(- highlightCircleSize)}, ${(yScale(accumulator))} )` );
             });
+        }
+
+        function unBlurPoint(point) {
+            d3Selection.select(point)
+                .attr('filter', 'none');
+        }
+
+        function blurPoint(point) {
+            if (!highlightFilter) {
+                highlightFilter = svg.select('.metadata-group')
+                  .append('defs')
+                    .append('filter')
+                      .attr('id', highlightFilterId);
+
+                highlightFilter
+                  .append('feGaussianBlur')
+                    .attr('stdDeviation', 1)
+                    .attr('result', 'coloredBlur');
+
+                // let merge = highlightFilter
+                //   .append('feMerge');
+                
+                // merge
+                //   .append('feMergeNode')
+                //     .attr('in', 'coloredBlur');
+                // merge
+                //   .append('feMergeNode')
+                //     .attr('in', 'SourceGraphic');
+                
+                    // <filter id="glow">
+                    //     <feGaussianBlur stdDeviation="2.5" result="coloredBlur" />
+                    //     <feMerge>
+                    //         <feMergeNode in="coloredBlur" />
+                    //         <feMergeNode in="SourceGraphic" />
+                    //     </feMerge>
+                    // </filter>
+
+                // <feGaussianBlur in="SourceGraphic" stdDeviation="15" result="blur" />
+                //     <feColorMatrix in="blur" mode="matrix"
+                //         values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 30 -7" result="goo" />
+                //     <feBlend in="SourceGraphic" in2="gblur" />
+            
+                // highlightFilter
+                //     .append('feColorMatrix')
+                //     .attr('mode', 'matrix')
+                //     .attr('in', 'blur')
+                //     .attr('values', '1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 30 -7')
+                //     .attr('result', 'goo')
+
+                // highlightFilter
+                //     .append('feBlend')
+                //     .attr('in2', 'gblur')
+                //     .attr('in', 'SourceGraphic')
+
+                }
+            
+            d3Selection.select(point)
+                .attr('filter', `url(#${highlightFilterId})`);
+                // debugger
         }
 
         /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding a svg filter with glow to the highlight points on the line and area charts

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/eventbrite/britecharts/issues/408

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran tests

![up3tspswyc](https://user-images.githubusercontent.com/190833/32988527-2ca0da3c-ccbb-11e7-9f68-e5936c795edc.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
