### PR TITLE
Feat donut empty

### DIFF
--- a/demos/donut.html
+++ b/demos/donut.html
@@ -87,11 +87,10 @@ donutContainer.datum(dataset).call(donutChart);
 
 <div class="container">
     <div class="row">
-        <div class="
-col-md-6">
+        <div class="col-md-6">
             <section>
                 <article>
-                    <h2>Donut Chart with fixed higlighted slice</h2>
+                    <h2>Donut Chart with fixed highlighted slice</h2>
                     <div class="js-donut-highlight-slice-chart-container card--chart"></div>
                 </article>
             </section>

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -14,6 +14,7 @@ define(function(require) {
     const textHelper = require('./helpers/text');
     const colorHelper = require('./helpers/colors');
     const {calculatePercent} = require('./helpers/common');
+    const {emptyDonutData} =require('./helpers/constants');
 
 
     /**
@@ -87,10 +88,16 @@ define(function(require) {
             svg,
 
             isAnimated = false,
+            isEmpty = false,
 
             highlightedSliceId,
             highlightedSlice,
             hasFixedHighlightedSlice = false,
+
+            emptyDataConfig = {
+                emptySliceColor: '#EFF2F5',
+                showEmptySlice: false
+            },
 
             quantityLabel = 'quantity',
             nameLabel = 'name',
@@ -144,6 +151,9 @@ define(function(require) {
 
                 if (highlightedSliceId) {
                     initHighlightSlice();
+                }
+                if (isEmpty && emptyDataConfig.showEmptySlice) {
+                    drawEmptySlice();
                 }
             });
         }
@@ -230,6 +240,7 @@ define(function(require) {
          * @private
          */
         function cleanData(data) {
+            let dataWithPercentages;
             let cleanData = data.reduce((acc, d) => {
                 // Skip data without quantity
                 if (d[quantityLabel] === undefined || d[quantityLabel] === null) {
@@ -244,17 +255,17 @@ define(function(require) {
             }, []);
 
             let totalQuantity = sumValues(cleanData);
-            let dataWithPercentages = cleanData.map((d) => {
-                let {percentage} = d;
 
-                if (numberFormat && percentage) {
-                    percentage = d3Format.format(numberFormat)(percentage);
-                }
+            if (totalQuantity === 0 && emptyDataConfig.showEmptySlice) {
+                isEmpty = true;
+            }
 
-                d.percentage = String(percentage || calculatePercent(d[quantityLabel], totalQuantity, percentageFormat));
+            dataWithPercentages = cleanData.map((d) => {
+                d.percentage = String(d.percentage || calculatePercent(d[quantityLabel], totalQuantity, percentageFormat));
 
                 return d;
-            });
+            }); 
+
 
             return dataWithPercentages;
         }
@@ -268,6 +279,33 @@ define(function(require) {
         }
 
         /**
+         * Draw an empty slice
+         * @private
+         */
+        function drawEmptySlice() {
+
+            if (slices) {
+                svg.selectAll('g.arc').remove();
+            }
+            slices = svg.select('.chart-group')
+                .selectAll('g.arc')
+                .data(layout(emptyDonutData));
+
+            let newSlices = slices.enter()
+                .append('g')
+                  .each(storeAngle)
+                  .each(reduceOuterRadius)
+                  .classed('arc', true)
+                  .append('path');
+        
+            newSlices.merge(slices)
+                .attr('fill', emptyDataConfig.emptySliceColor)
+                .attr('d', shape)
+            
+            slices.exit().remove();
+        }
+
+        /**
          * Draws the values on the donut slice inside the text element
          *
          * @param  {Object} obj Data object
@@ -275,8 +313,9 @@ define(function(require) {
          */
         function drawLegend(obj) {
             if (obj.data) {
+
                 svg.select('.donut-text')
-                    .text(() => `${obj.data.percentage}% ${ obj.data.name}`)
+                    .text(() => `${obj.data.percentage}% ${obj.data.name}`)
                     .attr('dy', '.2em')
                     .attr('text-anchor', 'middle');
 
@@ -507,6 +546,21 @@ define(function(require) {
                 return colorSchema;
             }
             colorSchema = _x;
+
+            return this;
+        };
+
+        /**
+         * Gets or Sets the emptyDataConfig of the chart
+         * @param  {Object} _x emptyDataConfig object to get/set
+         * @return { Object | module} Current config for when chart data is an empty array
+         * @public
+         */
+        exports.emptyDataConfig = function(_x) {
+            if (!arguments.length) {
+                return emptyDataConfig;
+            }
+            emptyDataConfig = _x;
 
             return this;
         };

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -551,10 +551,13 @@ define(function(require) {
         };
 
         /**
-         * Gets or Sets the emptyDataConfig of the chart
+         * Gets or Sets the emptyDataConfig of the chart. If set and data is empty (quantity
+         * adds up to zero or there are no entries), the chart will render an empty slice
+         * with a given color (light gray by default)
          * @param  {Object} _x emptyDataConfig object to get/set
          * @return { Object | module} Current config for when chart data is an empty array
          * @public
+         * @example donutChart.emptyDataConfig({showEmptySlice: true, emptySliceColor: '#000000'})
          */
         exports.emptyDataConfig = function(_x) {
             if (!arguments.length) {

--- a/src/charts/helpers/common.js
+++ b/src/charts/helpers/common.js
@@ -26,11 +26,13 @@ define(function(require) {
      * @return {String}           Percentage
      */
     function calculatePercent(value, total, decimals) {
-        return d3Format.format(decimals)(value / total * 100);
+        const percent = total ? (value / total * 100) : 0;
+
+        return d3Format.format(decimals)(percent);
     }
 
     /**
-     * Calculate diference between dates in days
+     * Calculate difference between dates in days
      * @param  {String}  date1 Date in string form
      * @param  {String}  date2 Date in string form
      * @return {Number}        Number of days between dates

--- a/src/charts/helpers/constants.js
+++ b/src/charts/helpers/constants.js
@@ -14,9 +14,16 @@ define(function() {
         ONE_DAY: 86400001
     };
 
+    const emptyDonutData = [{
+        'quantity': 1,
+        'percentage': 100
+    }];
+
     return {
         axisTimeCombinations,
-        timeBenchmarks
+        emptyDonutData,
+        timeBenchmarks,
+        lineGradientId: 'lineGradientId'
     };
 });
 

--- a/test/fixtures/donutChartDataBuilder.js
+++ b/test/fixtures/donutChartDataBuilder.js
@@ -6,6 +6,7 @@ define(function(require) {
         jsonFivePlusOther = require('json-loader!../json/donutDataFivePlusOther.json'),
         jsonFivePlusOtherNoPercent = require('json-loader!../json/donutDataFivePlusOtherNoPercent.json'),
         jsonOneZeroed = require('json-loader!../json/donutDataOneZeroed.json'),
+        jsonAllZeroed = require('json-loader!../json/donutDataAllZeroed.json'),
         jsonThreeCategories = require('json-loader!../json/donutDataThreeCategories.json');
 
 
@@ -34,6 +35,13 @@ define(function(require) {
 
         this.withOneTopicAtZero = function() {
             var attributes = _.extend({}, this.config, jsonOneZeroed);
+
+            return new this.Klass(attributes);
+        };
+
+
+        this.withAllTopicsAtZero = function() {
+            var attributes = _.extend({}, this.config, jsonAllZeroed);
 
             return new this.Klass(attributes);
         };

--- a/test/json/donutDataAllZeroed.json
+++ b/test/json/donutDataAllZeroed.json
@@ -1,0 +1,14 @@
+{
+    "data": [
+        {
+            "name": "Shiny",
+            "id": 11,
+            "quantity": 0
+        },
+        {
+            "name": "Radiant",
+            "id": 12,
+            "quantity": 0
+        }
+    ]
+}

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -101,9 +101,9 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                     containerFixture.datum(dataset).call(donutChart);
                     
                     let paths = containerFixture.selectAll('path').nodes();
-                    let actualFirstPathFill = d3.select(paths[0]).attr('fill');
-                    let actualSecondPathFill = d3.select(paths[1]).attr('fill');
-                    let actualThirdPathFill = d3.select(paths[2]).attr('fill');
+                    let actualFirstPathFill = paths[0].getAttribute('fill');
+                    let actualSecondPathFill = paths[1].getAttribute('fill');
+                    let actualThirdPathFill = paths[2].getAttribute('fill');
 
                     expect(actualFirstPathFill).toEqual(expectedFills[0]);
                     expect(actualSecondPathFill).toEqual(expectedFills[1]);
@@ -176,7 +176,7 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
 
                     let paths = containerFixture.selectAll('.donut-chart .arc path').nodes();
                    
-                    actual = d3.select(paths[0]).attr('fill');
+                    actual = paths[0].getAttribute('fill');
 
                     expect(actual).toEqual(expected);
 
@@ -214,14 +214,11 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                     }
 
                     donutChart.emptyDataConfig(emptyDataConfig);
-
-                    let dataset = [];
-
-                    containerFixture.datum(dataset).call(donutChart);
+                    containerFixture.datum([]).call(donutChart);
 
                     let paths = containerFixture.selectAll('.donut-chart .arc path').nodes();
 
-                    actual = d3.select(paths[0]).attr('fill');
+                    actual = paths[0].getAttribute('fill');
 
                     expect(actual).toEqual(expected);
 

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -111,6 +111,130 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                 });
             });
 
+
+            describe('when all sections are zero and emptyDataConfig.showEmptySlice', () => {
+
+                it('percentage label should be 0%', () => {
+                    let actual;
+                    let expected = '0.0%';
+
+                    let emptyDataConfig = {
+                        emptySliceColor: '#EFF2F5',
+                        showEmptySlice: true,
+                    }
+
+                    let dataset = aTestDataSet()
+                        .withAllTopicsAtZero()
+                        .build();
+
+                    donutChart.highlightSliceById(11)
+                    donutChart.emptyDataConfig(emptyDataConfig);
+
+                    containerFixture.datum(dataset).call(donutChart);
+
+                    let textNodes = containerFixture.select('text.donut-text .value').nodes();
+                    actual = d3.select(textNodes[0]).text();
+  
+                    expect(expected).toEqual(actual);
+
+                });
+
+                it('should render a single filler slice', () => {
+                    let actual;
+                    let expected = 1;
+
+                    let emptyDataConfig = {
+                        emptySliceColor: '#EFF2F5',
+                        showEmptySlice: true,
+                    }
+
+                    let dataset = aTestDataSet()
+                        .withAllTopicsAtZero()
+                        .build();
+
+                    donutChart.emptyDataConfig(emptyDataConfig);
+                    
+                    containerFixture.datum(dataset).call(donutChart);
+
+                    actual = containerFixture.selectAll('.donut-chart .arc path').nodes().length;
+
+                    expect(actual).toEqual(expected);
+
+                });
+
+                it('should fill the empty slice with emptyDataConfig.emptySliceColor', () => {
+                    let actual;
+                    let expected = '#000000';
+
+                    let emptyDataConfig = {
+                        emptySliceColor: expected,
+                        showEmptySlice: true,
+                    }
+
+                    donutChart.emptyDataConfig(emptyDataConfig);
+
+                    let dataset = aTestDataSet()
+                        .withAllTopicsAtZero()
+                        .build();
+
+                    containerFixture.datum(dataset).call(donutChart);
+
+                    let paths = containerFixture.selectAll('.donut-chart .arc path').nodes();
+
+                    actual = d3.select(paths[0]).attr('fill');
+
+                    expect(actual).toEqual(expected);
+
+                });
+
+            });
+
+            describe('when data is empty and emptyDataConfig.showEmptySlice', () => {
+
+                it('should render a single filler slice', () => {
+                    let actual;
+                    let expected = 1;
+
+                    let emptyDataConfig = {
+                        emptySliceColor: '#000000',
+                        showEmptySlice: true,
+                    }
+
+                    donutChart.emptyDataConfig(emptyDataConfig);
+                    containerFixture.datum([]).call(donutChart);
+
+                    actual = containerFixture.selectAll('.donut-chart .arc path').nodes().length;
+
+                    expect(actual).toEqual(expected);
+
+                });
+
+                it('should fill the empty slice with emptyDataConfig.emptySliceColor', () => {
+                    let actual;
+                    let expected = '#000000';
+
+                    let emptyDataConfig = {
+                        emptySliceColor: expected,
+                        showEmptySlice: true,
+                    }
+
+                    donutChart.emptyDataConfig(emptyDataConfig);
+
+                    let dataset = [];
+
+                    containerFixture.datum(dataset).call(donutChart);
+
+                    let paths = containerFixture.selectAll('.donut-chart .arc path').nodes();
+
+                    actual = d3.select(paths[0]).attr('fill');
+
+                    expect(actual).toEqual(expected);
+
+                });
+
+
+            });
+
             describe('when reloading with a one item dataset', () => {
 
                 it('should render in the same svg', function() {

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -129,10 +129,10 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
 
                     donutChart.highlightSliceById(11)
                     donutChart.emptyDataConfig(emptyDataConfig);
-
                     containerFixture.datum(dataset).call(donutChart);
 
                     let textNodes = containerFixture.select('text.donut-text .value').nodes();
+                   
                     actual = d3.select(textNodes[0]).text();
   
                     expect(expected).toEqual(actual);
@@ -153,9 +153,7 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                         .build();
 
                     donutChart.emptyDataConfig(emptyDataConfig);
-                    
                     containerFixture.datum(dataset).call(donutChart);
-
                     actual = containerFixture.selectAll('.donut-chart .arc path').nodes().length;
 
                     expect(actual).toEqual(expected);
@@ -165,22 +163,19 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                 it('should fill the empty slice with emptyDataConfig.emptySliceColor', () => {
                     let actual;
                     let expected = '#000000';
-
                     let emptyDataConfig = {
                         emptySliceColor: expected,
                         showEmptySlice: true,
                     }
-
-                    donutChart.emptyDataConfig(emptyDataConfig);
-
                     let dataset = aTestDataSet()
                         .withAllTopicsAtZero()
                         .build();
 
+                    donutChart.emptyDataConfig(emptyDataConfig);
                     containerFixture.datum(dataset).call(donutChart);
 
                     let paths = containerFixture.selectAll('.donut-chart .arc path').nodes();
-
+                   
                     actual = d3.select(paths[0]).attr('fill');
 
                     expect(actual).toEqual(expected);
@@ -255,7 +250,6 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                     let newDataset = buildDataSet('withThreeCategories');
                     
                     containerFixture.datum(newDataset).call(donutChart);
-                    
                     actual = containerFixture.selectAll('.donut-chart .arc').nodes().length;
 
                     expect(actual).toEqual(expected);
@@ -267,7 +261,6 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                     let newDataset = buildDataSet('withThreeCategories');
                     
                     containerFixture.datum(newDataset).call(donutChart);
-                    
                     actual = containerFixture.selectAll('.donut-chart .arc path').nodes().length;
     
                     expect(actual).toEqual(expected);


### PR DESCRIPTION
Adds an empty state for the donut chart. For backwards compatibility, it defaults to false.

## Description
Renders an empty slice with a piece of spoofed data. Keeps the other slices around so that they can be shown as highlighted slices in the tooltip.

## Motivation and Context
We need an empty donut chart for a spec.

## How Has This Been Tested?
I added tests to ensure that in both cases where data is an empty array and when data is an array of objects each with quantity zero, if the empty state is configured on, an empty slice will be rendered. The tests also check the the custom empty state color applies in each of these cases.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
