### PR TITLE
Fixes Brush Selection Movement (#427)

### DIFF
--- a/src/charts/brush.js
+++ b/src/charts/brush.js
@@ -249,7 +249,7 @@ define(function(require) {
         }
 
         /**
-         * Cleaning data casting the values and dates to the proper type while keeping 
+         * Cleaning data casting the values and dates to the proper type while keeping
          * the rest of properties on the data
          * @param  {BrushChartData} originalData        Raw data from the container
          * @return {BrushChartData}                     Clean data
@@ -320,7 +320,7 @@ define(function(require) {
                 .classed('brush-rect', true)
                 .attr('height', chartHeight);
 
-            chartBrush.select('.selection')
+            chartBrush.selectAll('.selection')
                 .attr('fill', `url(#${gradientId})`);
         }
 


### PR DESCRIPTION
## Description
Enables the brush selection to be dragged. 

## Motivation and Context
`.selection` was being selected with `select` vs `selectAll`

Fixes https://github.com/eventbrite/britecharts/issues/427

## How Has This Been Tested?
Tested this in docs locally. Tried to figure a way to write a test but couldn't figure out a way to simulate the movement. If you have any ideas I'm happy to write a test. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
