### PR TITLE
Fix data requirements: Issue #447

### DIFF
--- a/src/charts/grouped-bar.js
+++ b/src/charts/grouped-bar.js
@@ -26,22 +26,19 @@ define(function (require) {
 
     /**
      * @typedef GroupedBarChartData
-     * @type {Object}
-     * @property {Object[]} data       All data entries
+     * @type {Object[]}
      * @property {String} name         Name of the entry
      * @property {String} group        group of the entry
      * @property {Number} value        Value of the entry
      *
      * @example
-     * {
-     *     'data': [
-     *         {
-     *             "name": "2011-01",
-     *             "group": "Direct",
-     *             "value": 0
-     *         }
-     *     ]
-     * }
+     * [
+     *     {
+     *         "name": "2011-01",
+     *         "group": "Direct",
+     *         "value": 0
+     *     }
+     * ]
      */
 
     /**
@@ -338,7 +335,7 @@ define(function (require) {
         }
 
         /**
-         * Cleaning data casting the values, groups, topic names and names to the proper type while keeping 
+         * Cleaning data casting the values, groups, topic names and names to the proper type while keeping
          * the rest of properties on the data
          * @param  {GroupedBarChartData} originalData   Raw data from the container
          * @return {GroupedBarChartData}                Parsed data with values and dates

--- a/src/charts/legend.js
+++ b/src/charts/legend.js
@@ -28,6 +28,7 @@ define(function(require){
      *         quantity: 3,
      *         name: 'luminous'
      *     }
+     * ]
      */
 
 

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -29,6 +29,7 @@ define(function(require){
      *         value: 2,
      *         date: '2011-01-07T00:00:00Z'
      *     }
+     * ]
      */
 
     /**
@@ -173,7 +174,7 @@ define(function(require){
         }
 
         /**
-         * Cleaning data casting the values and dates to the proper type while keeping 
+         * Cleaning data casting the values and dates to the proper type while keeping
          * the rest of properties on the data
          * @param  {SparklineChartData} originalData    Raw data from the container
          * @return {SparklineChartData}                 Clean data
@@ -341,7 +342,7 @@ define(function(require){
             areaGradient = _x;
             return this;
         };
-    
+
         /**
          * Gets or Sets the dateLabel of the chart
          * @param  {Number} _x Desired dateLabel for the graph

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -44,22 +44,19 @@ define(function(require){
 
     /**
      * @typedef areaChartData
-     * @type {Object}
-     * @property {Object[]} data       All data entries
+     * @type {Object[]}
      * @property {String} date         Date of the entry
      * @property {String} name         Name of the entry
      * @property {Number} value        Value of the entry
      *
      * @example
-     * {
-     *     'data': [
-     *         {
-     *             "date": "2011-01-05T00:00:00Z",
-     *             "name": "Direct",
-     *             "value": 0
-     *         }
-     *     ]
-     * }
+     * [
+     *     {
+     *         "date": "2011-01-05T00:00:00Z",
+     *         "name": "Direct",
+     *         "value": 0
+     *     }
+     * ]
      */
 
     /**
@@ -112,10 +109,10 @@ define(function(require){
             highlightCircleSize = 12,
             highlightCircleRadius = 5,
             highlightCircleStroke = 1.2,
-            highlightCircleActiveRadius = highlightCircleRadius + 2,       
-            highlightCircleActiveStrokeWidth = 5, 
-            highlightCircleActiveStrokeOpacity = 0.6,     
-            
+            highlightCircleActiveRadius = highlightCircleRadius + 2,
+            highlightCircleActiveStrokeWidth = 5,
+            highlightCircleActiveStrokeOpacity = 0.6,
+
             areaOpacity = 0.24,
             categoryColorMap,
             order,
@@ -140,7 +137,7 @@ define(function(require){
             areaAnimationDelays = d3Array.range(areaAnimationDelayStep, maxAreaNumber* areaAnimationDelayStep, areaAnimationDelayStep),
 
             overlay,
-            overlayColor = 'rgba(0, 0, 0, 0)',            
+            overlayColor = 'rgba(0, 0, 0, 0)',
             verticalMarkerContainer,
             verticalMarkerLine,
             epsilon,
@@ -223,7 +220,7 @@ define(function(require){
 
         /**
          * Adds a filter to the element
-         * @param {DOMElement} el 
+         * @param {DOMElement} el
          * @private
          */
         function addGlowFilter(el) {
@@ -492,7 +489,7 @@ define(function(require){
         }
 
         /**
-         * Cleaning data casting the values and dates to the proper type while keeping 
+         * Cleaning data casting the values and dates to the proper type while keeping
          * the rest of properties on the data. It creates fake data is the data is empty.
          * @param  {areaChartData} originalData   Raw data from the container
          * @return {areaChartData}                Parsed data with values and dates
@@ -504,7 +501,7 @@ define(function(require){
             return originalData.reduce((acc, d) => {
                 d.date = new Date(d[dateLabel]),
                 d.value = +d[valueLabel]
-    
+
                 return [...acc, d];
             }, []);
         }
@@ -703,7 +700,7 @@ define(function(require){
 
             if (isUsingFakeData) {
                 drawEmptyDataLine();
-                
+
                 return;
             }
 
@@ -1296,7 +1293,7 @@ define(function(require){
             width = _x;
 
             return this;
-        };        
+        };
 
         /**
          * Exposes the ability to force the chart to show a certain x format

--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -27,22 +27,19 @@ define(function(require){
 
     /**
      * @typedef stackedBarData
-     * @type {Object}
-     * @property {Object[]} data       All data entries
+     * @type {Object[]}
      * @property {String} name         Name of the entry
      * @property {String} stack        Stack of the entry
      * @property {Number} value        Value of the entry
      *
      * @example
-     * {
-     *     'data': [
-     *         {
-     *             "name": "2011-01",
-     *             "stack": "Direct",
-     *             "value": 0
-     *         }
-     *     ]
-     * }
+     * [
+     *     {
+     *         "name": "2011-01",
+     *         "stack": "Direct",
+     *         "value": 0
+     *     }
+     * ]
      */
 
     /**
@@ -107,7 +104,7 @@ define(function(require){
             data,
             transformedData,
             stacks,
-            layerElements,            
+            layerElements,
 
             tooltipThreshold = 480,
 
@@ -330,7 +327,7 @@ define(function(require){
         }
 
         /**
-         * Cleaning data casting the values, stacks, names and topic names to the proper type while keeping 
+         * Cleaning data casting the values, stacks, names and topic names to the proper type while keeping
          * the rest of properties on the data
          * @param  {stackedBarData} originalData   Raw data from the container
          * @return {stackedBarData}                Parsed data with values and dates
@@ -431,7 +428,7 @@ define(function(require){
             let barJoin = layerElements
                 .selectAll('.bar')
                 .data((d) => d);
-                    
+
             // Enter + Update
             let bars = barJoin
                     .enter()


### PR DESCRIPTION
## Description
This PR updates documentation for grouped-bar, stacked-area, and stacked-bar charts by removing the data property and updating the type and example. It also adds an end bracket to the sparkline and legend chart examples.

## Motivation and Context
On https://eventbrite.github.io/britecharts/global.html, some charts show examples with a data property, others don't. This PR fixes issue 447 by making the documentation style the same, https://github.com/eventbrite/britecharts/issues/447. 

## How Has This Been Tested?
I ran ```yarn run docs``` to make sure the changes were made. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. (Executed 380 of 390 (skipped 10))
