### PR TITLE
Feature - custom click handler for the Bar charts

### DIFF
--- a/demos/demo-bar.js
+++ b/demos/demo-bar.js
@@ -101,7 +101,7 @@ if (d3Selection.select('.js-bar-chart-tooltip-container').node()){
     createBarChartWithTooltip();
     createHorizontalBarChart();
     createSimpleBarChart();
-    
+
     let redrawCharts = function(){
         d3Selection.selectAll('.bar-chart').remove();
         createBarChartWithTooltip();

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -115,7 +115,12 @@ define(function(require) {
 
             // Dispatcher object to broadcast the mouse events
             // Ref: https://github.com/mbostock/d3/wiki/Internals#d3_dispatch
-            dispatcher = d3Dispatch.dispatch('customMouseOver', 'customMouseOut', 'customMouseMove'),
+            dispatcher = d3Dispatch.dispatch(
+                'customMouseOver',
+                'customMouseOut',
+                'customMouseMove',
+                'customClick'
+            ),
 
             // extractors
             getName = ({name}) => name,
@@ -353,6 +358,9 @@ define(function(require) {
                 .on('mouseout', function(d) {
                     handleMouseOut(this, d, chartWidth, chartHeight);
                 })
+                .on('click', function(d) {
+                    handleClick(this, d, chartWidth, chartHeight);
+                })
               .merge(bars)
                 .attr('x', 0)
                 .attr('y', ({name}) => yScale(name))
@@ -383,6 +391,9 @@ define(function(require) {
                 })
                 .on('mouseout', function(d) {
                     handleMouseOut(this, d, chartWidth, chartHeight);
+                })
+                .on('click', function(d) {
+                    handleClick(this, d, chartWidth, chartHeight);
                 });
 
             bars
@@ -420,6 +431,9 @@ define(function(require) {
                 .on('mouseout', function(d) {
                     handleMouseOut(this, d, chartWidth, chartHeight);
                 })
+                .on('click', function(d) {
+                    handleClick(this, d, chartWidth, chartHeight);
+                })
               .merge(bars)
                 .attr('x', ({name}) => xScale(name))
                 .attr('width', xScale.bandwidth())
@@ -454,6 +468,9 @@ define(function(require) {
                 })
                 .on('mouseout', function(d) {
                     handleMouseOut(this, d, chartWidth, chartHeight);
+                })
+                .on('click', function(d) {
+                    handleClick(this, d, chartWidth, chartHeight);
                 })
               .merge(bars)
                 .attr('x', ({name}) => xScale(name))
@@ -645,6 +662,15 @@ define(function(require) {
             d3Selection.select(e).attr('fill', ({name}) => colorMap(name));
         }
 
+        /**
+         * Custom onClick event handler
+         * @return {void}
+         * @private
+         */
+        function handleClick(e, d, chartWidth, chartHeight) {
+            dispatcher.call('customClick', e, d, d3Selection.mouse(e), [chartWidth, chartHeight]);
+        }
+
         // API
 
         /**
@@ -796,7 +822,7 @@ define(function(require) {
         /**
          * Exposes an 'on' method that acts as a bridge with the event dispatcher
          * We are going to expose this events:
-         * customMouseOver, customMouseMove and customMouseOut
+         * customMouseOver, customMouseMove, customMouseOut, and customClick
          *
          * @return {module} Bar Chart
          * @public

--- a/test/specs/bar.spec.js
+++ b/test/specs/bar.spec.js
@@ -61,7 +61,7 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
         });
 
         describe('when reloading with a different dataset', () => {
-            
+
             it('should render in the same svg', function() {
                 let actual;
                 let expected = 1;
@@ -89,7 +89,7 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
         });
 
         describe('when orderingFunction is called', () => {
-            
+
             it('accepts custom descending order function', () => {
                 let fn = (a, b) => b.value - a.value; 
                 let actual,
@@ -112,7 +112,7 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
                     expected = {
                         name: 'Z',
                         value: 0.00074
-                    }; 
+                    };
 
                 barChart.orderingFunction(fn);
                 containerFixture.call(barChart)
@@ -220,10 +220,10 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
                 let previous = barChart.betweenBarsPadding(),
                     expected = 0.5,
                     actual;
-                
+
                 barChart.betweenBarsPadding(expected);
                 actual = barChart.betweenBarsPadding();
-                
+
                 expect(previous).not.toBe(actual);
                 expect(actual).toBe(expected);
             });
@@ -358,6 +358,20 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
 
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);
+            });
+        });
+
+        describe('when clicking on a bar', function() {
+
+            it('should trigger a callback on mouse click', () => {
+                let bar = containerFixture.selectAll('.bar:nth-child(1)');
+                let callbackSpy = jasmine.createSpy('callback');
+
+                barChart.on('customClick', callbackSpy);
+                bar.dispatch('click');
+
+                expect(callbackSpy.calls.count()).toBe(1);
+                expect(callbackSpy.calls.allArgs()[0].length).toBe(3);
             });
         });
 


### PR DESCRIPTION
Implemented a custom click handler for the Bar charts, that will pass data point via callback.

## Description
* Added new `customClick` action in `/charts/bar.js` to all types of bar charts.
* Dispatched the action via `click` event.
* Added `customClick` to the comment section above `.on` method.

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/442

## How Has This Been Tested?
* Added test in `bar.spec.js` with a new `describe` stub that checks whether the callback of the click event was triggered -- very similar to other event handler tests.
* Ran `yarn test`.

## Screenshots (if appropriate):
I can print the clicked data point of the Bar chart and log it out 🖨 
<img width="1424" alt="screen shot 2017-12-18 at 11 55 20 pm" src="https://user-images.githubusercontent.com/31934144/34146472-095a9d5a-e44f-11e7-83a0-45c6687a4261.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
