### PR TITLE
Feature - Added .numberFormat to MiniTooltip

### DIFF
--- a/demos/bar.html
+++ b/demos/bar.html
@@ -21,6 +21,9 @@ barChart
 
 barContainer.datum(dataset).call(barChart);
 
+tooltip
+    .numberFormat('.2%');
+
 tooltipContainer = d3.select('.bar-chart .metadata-group');
 tooltipContainer.datum([]).call(tooltip);
                 </code></pre>

--- a/demos/demo-bar.js
+++ b/demos/demo-bar.js
@@ -91,6 +91,9 @@ function createBarChartWithTooltip() {
 
         barContainer.datum(dataset).call(barChart);
 
+        tooltip
+            .numberFormat('.2%')
+
         tooltipContainer = d3Selection.select('.bar-chart .metadata-group');
         tooltipContainer.datum([]).call(tooltip);
     }

--- a/src/charts/mini-tooltip.js
+++ b/src/charts/mini-tooltip.js
@@ -7,6 +7,7 @@ define(function(require){
     const d3Selection = require('d3-selection');
     const d3Transition = require('d3-transition');
 
+    const NUMBER_FORMAT = '.2f';
 
     /**
      * Mini Tooltip Component reusable API class that renders a
@@ -83,7 +84,8 @@ define(function(require){
             valueTextWeight = 200,
 
             // formats
-            tooltipValueFormat = d3Format.format('.2f'),
+            numberFormat = NUMBER_FORMAT,
+            valueFormatter = (value) => d3Format.format(numberFormat)(value),
 
             chartWidth,
             chartHeight,
@@ -297,7 +299,7 @@ define(function(require){
                     .style('fill', valueTextFillColor)
                     .style('font-size', valueTextSize)
                     .style('font-weight', valueTextWeight)
-                    .text(tooltipValueFormat(value));
+                    .text(valueFormatter(value));
 
                 temporalHeight = valueLineHeight + temporalHeight;
             }
@@ -361,6 +363,20 @@ define(function(require){
             nameLabel = _x;
             return this;
         };
+
+        /**
+         * Gets or Sets the number format for the value displayed on the tooltip
+         * @param  {string} [_x=".2f"] Desired number format
+         * @return {string | module} Current numberFormat or Chart module to chain calls
+         * @public
+         */
+        exports.numberFormat = function(_x) {
+            if (!arguments.length) {
+                return numberFormat;
+            }
+            numberFormat = _x;
+            return this;
+        }
 
         /**
          * Shows the tooltip

--- a/test/specs/mini-tooltip.spec.js
+++ b/test/specs/mini-tooltip.spec.js
@@ -129,6 +129,18 @@ define(['jquery', 'd3', 'mini-tooltip'], function($, d3, tooltip) {
                 expect(actual).toBe(expected);
             });
 
+            it('should provide numberFormat getter and setter', () => {
+                let current = tooltipChart.numberFormat(),
+                    expected = '.2%',
+                    actual;
+
+                tooltipChart.numberFormat(expected);
+                actual = tooltipChart.numberFormat();
+
+                expect(current).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
             it('should provide nameLabel getter and setter', () => {
                 let defaultNameLabel = 'key',
                     testNameLabel = 'label',


### PR DESCRIPTION
## Description
Added `.numberFormat` public function to MiniTooltip, it's used to set the format of the value shown on the tooltip.

## How Has This Been Tested?
Added API spec and BarChart demo code with usage of tooltip.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
