### PR TITLE
Removed .usePercentage from BarChart

### DIFF
--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -930,25 +930,6 @@ define(function(require) {
         };
 
         /**
-         * Gets or Sets the numberFormat to a percentage format if true (default false)
-         * @param  {boolean} _x     Should use percentage as value format
-         * @return { boolean | module} Is percentage the value format used or Chart module to chain calls
-         * @public
-         */
-        exports.usePercentage = function(_x) {
-            if (!arguments.length) {
-                return numberFormat === PERCENTAGE_FORMAT;
-            }
-            if (_x) {
-                numberFormat = PERCENTAGE_FORMAT;
-            } else {
-                numberFormat = NUMBER_FORMAT;
-            }
-
-            return this;
-        };
-
-        /**
          * Gets or Sets the valueLabel of the chart
          * @param  {Number} _x Desired valueLabel for the graph
          * @return { valueLabel | module} Current valueLabel or Chart module to chain calls

--- a/test/specs/bar.spec.js
+++ b/test/specs/bar.spec.js
@@ -288,7 +288,7 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
                 expect(actual).toBe(expected);
             });
 
-            it('should provide an usePercentage getter and setter', () => {
+            it('should provide an hasPercentage getter and setter', () => {
                 let previous = barChart.hasPercentage(),
                     expected = true,
                     actual;


### PR DESCRIPTION
## Description
Removed the deprecated method `.usePercentage`.

## Motivation and Context
See #464.

## How Has This Been Tested?
API specs

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
