### PR TITLE
Feat - added hasPercentage method to Stacked Bar 

### DIFF
--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -18,6 +18,7 @@ define(function(require){
     const colorHelper = require('./helpers/colors');
     const {bar} = require('./helpers/loadingStates');
 
+    const PERCENTAGE_FORMAT = '%';
     const NUMBER_FORMAT = ',f';
     const uniq = (arrArg) => arrArg.filter((elem, pos, arr) => arr.indexOf(elem) == pos);
 
@@ -822,6 +823,25 @@ define(function(require){
                 return grid;
             }
             grid = _x;
+
+            return this;
+        };
+
+        /**
+         * Gets or Sets the hasPercentage status
+         * @param  {boolean} _x     Should use percentage as value format
+         * @return { boolean | module} Is percentage used or Chart module to chain calls
+         * @public
+         */
+        exports.hasPercentage = function(_x) {
+            if (!arguments.length) {
+                return valueLabelFormat === PERCENTAGE_FORMAT;
+            }
+            if (_x) {
+                valueLabelFormat = PERCENTAGE_FORMAT;
+            } else {
+                valueLabelFormat = NUMBER_FORMAT;
+            }
 
             return this;
         };

--- a/test/specs/stacked-bar.spec.js
+++ b/test/specs/stacked-bar.spec.js
@@ -174,6 +174,18 @@ define(['d3', 'stacked-bar', 'stackedBarDataBuilder'], function(d3, chart, dataB
                 expect(actual).toBe(expected);
             });
 
+            it('should provide an hasPercentage getter and setter', () => {
+                let previous = stackedBarChart.hasPercentage(),
+                    expected = true,
+                    actual;
+
+                stackedBarChart.hasPercentage(expected);
+                actual = stackedBarChart.hasPercentage();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
             it('should provide height getter and setter', () => {
                 let previous = stackedBarChart.height(),
                     expected = {top: 4, right: 4, bottom: 4, left: 4},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added a method for `hasPercentage` that behaves like one in a `Bar` chart.

## Description
Added new method that is exported in `src/stacked-bar.js` and tests. This method will allow users to apply percentage format to the values in the `valueLabel` axis. 

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/458

## How Has This Been Tested?
Added a test in `stacked-bar.spec.js` that tests whether the format has changed.

## Screenshots (if appropriate):
The values given to the example are too high, that's why the values on this are converted to outrageous values.
![screen shot 2018-01-17 at 8 27 38 pm](https://user-images.githubusercontent.com/31934144/35080926-97f3ff38-fbc5-11e7-82be-a7ce47fee23d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
