### PR TITLE
Eliminated mutation of data in cleanData of the Line chart

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -513,13 +513,11 @@ define(function(require){
             let newDataByTopic = dataByTopic.reduce((accum, topic) => {
                 let {dates, ...restProps} = topic;
 
-                let newDates = dates.map(d => {
-                    return {
+                let newDates = dates.map(d => ({
                        date: new Date(d[dateLabel]),
                        value: +d[valueLabel],
                        [dateLabel]: d[dateLabel]
-                    }
-                })
+                }));
 
                 accum.push({...restProps, dates: newDates});
 

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -519,7 +519,7 @@ define(function(require){
                        [dateLabel]: d[dateLabel]
                 }));
 
-                accum.push({...restProps, dates: newDates});
+                accum.push({ dates: newDates, ...restProps });
 
                 return accum;
              }, []);

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -494,7 +494,7 @@ define(function(require){
 
             // Nest data by date and format
             dataByDate = d3Collection.nest()
-                            .key( getDate )
+                            .key(getDate)
                             .entries(flatData)
                             .map((d) => {
                                 return {
@@ -510,15 +510,26 @@ define(function(require){
                 return d;
             });
 
-            // Normalize dataByTopic
-            dataByTopic.forEach(function(kv) {
-                kv.dates.forEach(function(d) {
-                    d.date = new Date(d[dateLabel]);
-                    d.value = +d[valueLabel];
-                });
-            });
+            let newDataByTopic = dataByTopic.reduce((accum, topic) => {
+                let {dates, ...restProps} = topic;
 
-            return {dataByTopic, dataByDate};
+                let newDates = dates.map(d => {
+                    return {
+                       date: new Date(d[dateLabel]),
+                       value: +d[valueLabel],
+                       [dateLabel]: d[dateLabel]
+                    }
+                })
+
+                accum.push({...restProps, dates: newDates});
+
+                return accum;
+             }, []);
+
+            return {
+                dataByTopic: newDataByTopic,
+                dataByDate
+            };
         }
 
         /**

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -479,18 +479,18 @@ define(function(require){
                 throw new Error('Data needs to have a dataByTopic property');
             }
 
-            let flatData = [];
-
-            dataByTopic.forEach((topic) => {
+            const flatData = dataByTopic.reduce((accum, topic) => {
                 topic.dates.forEach((date) => {
-                    flatData.push({
+                    accum.push({
                         topicName: topic[topicNameLabel],
                         name: topic[topicLabel],
                         date: date[dateLabel],
                         value: date[valueLabel]
                     });
                 });
-            });
+
+                return accum;
+            }, []);
 
             // Nest data by date and format
             dataByDate = d3Collection.nest()
@@ -510,7 +510,7 @@ define(function(require){
                 return d;
             });
 
-            let newDataByTopic = dataByTopic.reduce((accum, topic) => {
+            const newDataByTopic = dataByTopic.reduce((accum, topic) => {
                 let {dates, ...restProps} = topic;
 
                 let newDates = dates.map(d => ({

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -188,7 +188,7 @@ define(function(require){
             dataByTopic,
             dataByDate,
 
-            dateLabel = 'date',
+            dateLabel = 'fullDate',
             valueLabel = 'value',
             topicLabel = 'topic',
             topicNameLabel = 'topicName',

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -515,8 +515,7 @@ define(function(require){
 
                 let newDates = dates.map(d => ({
                        date: new Date(d[dateLabel]),
-                       value: +d[valueLabel],
-                    //    'fullDate': d[dateLabel]
+                       value: +d[valueLabel]
                 }));
 
                 accum.push({ dates: newDates, ...restProps });

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -6,7 +6,7 @@ define(function(require){
     const d3Collection = require('d3-collection');
     const d3Dispatch = require('d3-dispatch');
     const d3Ease = require('d3-ease');
-    const d3Format = require('d3-format');    
+    const d3Format = require('d3-format');
     const d3Scale = require('d3-scale');
     const d3Shape = require('d3-shape');
     const d3Selection = require('d3-selection');
@@ -30,7 +30,7 @@ define(function(require){
         formatIntegerValue,
         formatDecimalValue,
     } = require('./helpers/formatHelpers');
-    const { 
+    const {
         isInteger,
         uniqueId
     } = require('./helpers/common');
@@ -159,7 +159,7 @@ define(function(require){
             highlightCircleStroke = 2,
             highlightCircleActiveRadius = highlightCircleRadius + 2,
             highlightCircleActiveStrokeWidth = 5,
-            highlightCircleActiveStrokeOpacity = 0.6,     
+            highlightCircleActiveStrokeOpacity = 0.6,
 
             xAxisFormat = null,
             xTicks = null,
@@ -223,7 +223,12 @@ define(function(require){
             getLineColor = ({topic}) => colorScale(topic),
 
             // events
-            dispatcher = d3Dispatch.dispatch('customMouseOver', 'customMouseOut', 'customMouseMove', 'customDataEntryClick');
+            dispatcher = d3Dispatch.dispatch(
+                'customMouseOver',
+                'customMouseOut',
+                'customMouseMove',
+                'customDataEntryClick'
+            );
         /**
          * This function creates the graph using the selection and data provided
          *
@@ -259,7 +264,7 @@ define(function(require){
 
         /**
          * Adds a filter to the element
-         * @param {DOMElement} el 
+         * @param {DOMElement} el
          * @private
          */
         function addGlowFilter(el) {

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -188,7 +188,7 @@ define(function(require){
             dataByTopic,
             dataByDate,
 
-            dateLabel = 'fullDate',
+            dateLabel = 'date',
             valueLabel = 'value',
             topicLabel = 'topic',
             topicNameLabel = 'topicName',
@@ -510,13 +510,13 @@ define(function(require){
                 return d;
             });
 
-            const newDataByTopic = dataByTopic.reduce((accum, topic) => {
+            const normalizedDataByTopic = dataByTopic.reduce((accum, topic) => {
                 let {dates, ...restProps} = topic;
 
                 let newDates = dates.map(d => ({
                        date: new Date(d[dateLabel]),
                        value: +d[valueLabel],
-                       [dateLabel]: d[dateLabel]
+                    //    'fullDate': d[dateLabel]
                 }));
 
                 accum.push({ dates: newDates, ...restProps });
@@ -525,7 +525,7 @@ define(function(require){
              }, []);
 
             return {
-                dataByTopic: newDataByTopic,
+                dataByTopic: normalizedDataByTopic,
                 dataByDate
             };
         }

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -254,6 +254,8 @@ define([
                             actual = xAxisLabels.text(),
                             expected = '00 AM';
 
+                            console.log(actual, expected)
+
                         expect(actual).toEqual(expected)
                     });
                 });

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -254,8 +254,6 @@ define([
                             actual = xAxisLabels.text(),
                             expected = '00 AM';
 
-                            console.log(actual, expected)
-
                         expect(actual).toEqual(expected)
                     });
                 });

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -627,7 +627,6 @@ define([
 
                     beforeEach(function() {
                         lineChart = chart().grid('vertical');
-                        lineChart.dateLabel('fullDate');
 
                         containerFixture = d3.select('.test-container').append('svg');
                         containerFixture.datum(dataset).call(lineChart);
@@ -643,7 +642,6 @@ define([
 
                     beforeEach(function() {
                         lineChart = chart().grid('full');
-                        lineChart.dateLabel('fullDate');
 
                         containerFixture = d3.select('.test-container').append('svg');
                         containerFixture.datum(dataset).call(lineChart);

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -228,7 +228,6 @@ define([
                 beforeEach(() => {
                     dataset = aTestDataSet().withHourDateRange().build();
                     lineChart = chart();
-                    lineChart.dateLabel('fullDate');
 
                     // DOM Fixture Setup
                     f = jasmine.getFixtures();

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -228,6 +228,7 @@ define([
                 beforeEach(() => {
                     dataset = aTestDataSet().withHourDateRange().build();
                     lineChart = chart();
+                    lineChart.dateLabel('fullDate');
 
                     // DOM Fixture Setup
                     f = jasmine.getFixtures();
@@ -626,6 +627,7 @@ define([
 
                     beforeEach(function() {
                         lineChart = chart().grid('vertical');
+                        lineChart.dateLabel('fullDate');
 
                         containerFixture = d3.select('.test-container').append('svg');
                         containerFixture.datum(dataset).call(lineChart);
@@ -641,6 +643,7 @@ define([
 
                     beforeEach(function() {
                         lineChart = chart().grid('full');
+                        lineChart.dateLabel('fullDate');
 
                         containerFixture = d3.select('.test-container').append('svg');
                         containerFixture.datum(dataset).call(lineChart);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently `cleanData` in `Bar` charts mutates the data. I attempted to make `cleanData` transformation to be immutable using `reduce`.

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/407

## How Has This Been Tested?
Ran `yarn test` and checked if all is OK visually.

## Screenshots (if appropriate):
Looks same as before.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
