### PR TITLE
Fix: stacked-bar no more choosing random color

### DIFF
--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -433,11 +433,11 @@ define(function(require){
             // Enter + Update
             let bars = barJoin
                     .enter()
-                    .append('rect')
-                    .classed('bar', true)
-                    .attr('x', (d) => xScale(d[0]) )
-                    .attr('y', (d) => yScale(d.data.key) )
-                    .attr('height', yScale.bandwidth());
+                      .append('rect')
+                        .classed('bar', true)
+                        .attr('x', (d) => xScale(d[0]) )
+                        .attr('y', (d) => yScale(d.data.key) )
+                        .attr('height', yScale.bandwidth());
 
             if (isAnimated) {
                 bars.style('opacity', barOpacity)
@@ -490,11 +490,11 @@ define(function(require){
             // Enter + Update
             let bars = barJoin
                     .enter()
-                    .append('rect')
-                    .classed('bar', true)
-                    .attr('x', (d) => xScale(d.data.key))
-                    .attr('y', (d) => yScale(d[1]))
-                    .attr('width', xScale.bandwidth );
+                      .append('rect')
+                        .classed('bar', true)
+                        .attr('x', (d) => xScale(d.data.key))
+                        .attr('y', (d) => yScale(d[1]))
+                        .attr('width', xScale.bandwidth );
 
             if (isAnimated) {
                 bars.style('opacity', barOpacity)

--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -301,15 +301,10 @@ define(function(require){
                 .domain(data.map(getStack));
 
             categoryColorMap = colorScale
-                .domain(data.map(getName)).domain()
+                .domain(data.map(getStack))
+                .domain()
                 .reduce((memo, item) => {
-                    data.forEach(function(v){
-                        if (getName(v) === item){
-                           memo[v.name] = colorScale(v.stack)
-                           memo[v.stack] = colorScale(v.stack)
-                           memo[v.stack + item] = colorScale(v.stack)
-                       }
-                   })
+                    memo[item] = colorScale(item)
                     return memo;
                 }, {});
         }
@@ -438,12 +433,11 @@ define(function(require){
             // Enter + Update
             let bars = barJoin
                     .enter()
-                      .append('rect')
-                        .classed('bar', true)
-                        .attr('x', (d) => xScale(d[0]) )
-                        .attr('y', (d) => yScale(d.data.key) )
-                        .attr('height', yScale.bandwidth())
-                        .attr('fill', (({data}) => categoryColorMap[`${data.stack}${data.key}`]));
+                    .append('rect')
+                    .classed('bar', true)
+                    .attr('x', (d) => xScale(d[0]) )
+                    .attr('y', (d) => yScale(d.data.key) )
+                    .attr('height', yScale.bandwidth());
 
             if (isAnimated) {
                 bars.style('opacity', barOpacity)
@@ -496,12 +490,11 @@ define(function(require){
             // Enter + Update
             let bars = barJoin
                     .enter()
-                      .append('rect')
-                        .classed('bar', true)
-                        .attr('x', (d) => xScale(d.data.key))
-                        .attr('y', (d) => yScale(d[1]))
-                        .attr('width', xScale.bandwidth )
-                        .attr('fill', (({data}) => categoryColorMap[`${data.stack}${data.key}`]));
+                    .append('rect')
+                    .classed('bar', true)
+                    .attr('x', (d) => xScale(d.data.key))
+                    .attr('y', (d) => yScale(d[1]))
+                    .attr('width', xScale.bandwidth );
 
             if (isAnimated) {
                 bars.style('opacity', barOpacity)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Stackedbar chart use the colors list as all others charts.

## Motivation and Context
The stackedbar chart use random color from the colors list, with this fix stackedbar use the colors list as all others charts.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`yarn test` -> OK
I did not succeed to run the demos, I tested with a chart I made 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
