### PR TITLE
Fix:  stackedbar get nearest datapoint

### DIFF
--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -573,12 +573,8 @@ define(function(require){
          */
         function getNearestDataPoint(mouseX) {
             const adjustedMouseX = mouseX - margin.left;
-            const dataByValueParsed = transformedData.map((item) => {
-                    item.key = item.key
-                    return item;
-                });
 
-            const nearest = dataByValueParsed.find(({key}) => {
+            const nearest = transformedData.find(({key}) => {
                 const barStart = xScale(key);
                 const barEnd = barStart + xScale.bandwidth();
 
@@ -596,11 +592,8 @@ define(function(require){
          */
         function getNearestDataPoint2(mouseY) {
             const adjustedMouseY = mouseY - margin.top;
-            const dataByValueParsed = transformedData.map((item) => {
-                item.key = item.key
-                return item;
-            });
-            const nearest = dataByValueParsed.find(({key}) => {
+
+            const nearest = transformedData.find(({key}) => {
                 const barStart = yScale(key);
                 const barEnd = barStart + yScale.bandwidth();
 

--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -583,7 +583,7 @@ define(function(require){
                 const barEnd = barStart + xScale.bandwidth();
 
                 // If mouseX is between barStart & barEnd
-                return (adjustedMouseX >= barStart) && (adjustedMouseX < barEnd)
+                return (adjustedMouseX >= barStart) && (adjustedMouseX < barEnd);
             });
 
             return nearest;
@@ -605,7 +605,7 @@ define(function(require){
                 const barEnd = barStart + yScale.bandwidth();
 
                 // If mouseY is between barStart & barEnd
-                return (adjustedMouseY >= barStart) && (adjustedMouseY < barEnd)
+                return (adjustedMouseY >= barStart) && (adjustedMouseY < barEnd);
             });
 
             return nearest;

--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -572,41 +572,43 @@ define(function(require){
          * @return {obj}            Data entry that is closer to that x axis position
          */
         function getNearestDataPoint(mouseX) {
-            let adjustedMouseX = mouseX - margin.left,
-                dataByValueParsed = transformedData.map((item) => {
+            const adjustedMouseX = mouseX - margin.left;
+            const dataByValueParsed = transformedData.map((item) => {
                     item.key = item.key
                     return item;
-                }),
-                epsilon,
-                nearest;
+                });
 
-            epsilon = (xScale(dataByValueParsed[1].key) - xScale(dataByValueParsed[0].key));
-            nearest = dataByValueParsed.find(({key}) => Math.abs(xScale(key) - adjustedMouseX) <= epsilon);
+            const nearest = dataByValueParsed.find(({key}) => {
+                const barStart = xScale(key);
+                const barEnd = barStart + xScale.bandwidth();
+
+                // If mouseX is between barStart & barEnd
+                return (adjustedMouseX >= barStart) && (adjustedMouseX < barEnd)
+            });
 
             return nearest;
         }
 
-         /**
-         * Finds out the data entry that is closer to the given position on pixels
+        /**
+         * Finds out the data entry that is closer to the given position on pixels (horizontal)
          * @param  {Number} mouseY  Y position of the mouse
          * @return {obj}            Data entry that is closer to that y axis position
          */
-
         function getNearestDataPoint2(mouseY) {
-            let adjustedMouseY = mouseY - margin.bottom,
-                epsilon = yScale.bandwidth(),
-                nearest;
-
-            nearest = layers.map(function(stackedArray){
-                return stackedArray.map(function(d1){
-                   let found = d1.data.values.find((d2) => Math.abs(adjustedMouseY >= yScale(d2[nameLabel])) && Math.abs(adjustedMouseY - yScale(d2[nameLabel]) <= epsilon*2) );
-
-                   return found ? d1.data :undefined;
-               })
+            const adjustedMouseY = mouseY - margin.top;
+            const dataByValueParsed = transformedData.map((item) => {
+                item.key = item.key
+                return item;
             });
-            nearest = d3Array.merge( nearest).filter(function(e){return e});
+            const nearest = dataByValueParsed.find(({key}) => {
+                const barStart = yScale(key);
+                const barEnd = barStart + yScale.bandwidth();
 
-            return nearest.length ? nearest[0] :undefined;
+                // If mouseY is between barStart & barEnd
+                return (adjustedMouseY >= barStart) && (adjustedMouseY < barEnd)
+            });
+
+            return nearest;
         }
 
         /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix stackedbar getNearestDatapoint functions.

## Description
Vertical stackedbar:
Get datapoint only when mouseX match position X of a bar (no more datapoint get between bars)

Horizontal stackedbar:
Get datapoint only when mouseY match position Y of a bar (no more datapoint get between bars)
Fix bad calculation when chart has margin top or margin bottom


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`yarn test` -> OK

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
