### PR TITLE
Allow valueFormat to be an empty string

### DIFF
--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -245,7 +245,7 @@ define(function(require){
             if (!value) {
                 return 0;
             }
-            if (valueFormat) {
+            if (valueFormat !== null) {
                 valueFormatter = d3Format.format(valueFormat);
             } else if (isInteger(value)) {
                 valueFormatter = formatIntegerValue;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow valueFormat to be an empty string

## Description
Allow to do d3Format.format('') that trim insignificant trailing zeros.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`yarn test` -> OK

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
