### PR TITLE
Feat: add possibility to precise the unit of the values in legend

### DIFF
--- a/src/charts/legend.js
+++ b/src/charts/legend.js
@@ -513,7 +513,7 @@ define(function(require){
             if (!arguments.length) {
                 return unit;
             }
-            suffix = _x;
+            unit = _x;
 
             return this;
         };

--- a/src/charts/legend.js
+++ b/src/charts/legend.js
@@ -84,6 +84,7 @@ define(function(require){
             valueReservedSpace = 40,
             numberLetterSpacing = 0.8,
             numberFormat = 's',
+            unit = '',
 
             isFadedClassName = 'is-faded',
             isHorizontal = false,
@@ -94,7 +95,7 @@ define(function(require){
 
             getId = ({id}) => id,
             getName = ({name}) => name,
-            getFormattedQuantity = ({quantity}) => d3Format.format(numberFormat)(quantity),
+            getFormattedQuantity = ({quantity}) => d3Format.format(numberFormat)(quantity) + unit,
             getCircleFill = ({name}) => colorScale(name),
 
             entries,
@@ -498,6 +499,21 @@ define(function(require){
                 return markerSize;
             }
             markerSize = _x;
+
+            return this;
+        };
+
+        /**
+         * Gets or Sets the unit of the value
+         * @param  {boolean} _x Desired unit
+         * @return {boolean | module} Current unit or Legend module to chain calls
+         * @public
+         */
+        exports.unit = function(_x) {
+            if (!arguments.length) {
+                return unit;
+            }
+            suffix = _x;
 
             return this;
         };

--- a/test/specs/legend.spec.js
+++ b/test/specs/legend.spec.js
@@ -240,6 +240,18 @@ define(['d3', 'legend', 'donutChartDataBuilder'], function(d3, legend, dataBuild
                     expect(previous).not.toBe(expected);
                     expect(actual).toBe(expected);
                 });
+
+                it('should provide unit getter and setter', () =>{
+                    let previous = legendChart.unit(),
+                        expected = 'unit',
+                        actual;
+
+                    legendChart.unit(expected);
+                    actual = legendChart.unit();
+
+                    expect(previous).not.toBe(expected);
+                    expect(actual).toBe(expected);
+                });
             });
         });
 
@@ -363,6 +375,46 @@ define(['d3', 'legend', 'donutChartDataBuilder'], function(d3, legend, dataBuild
                             .size();
 
                     expect(actual).toEqual(expected);
+                });
+            });
+        });
+
+        describe('when legend has unit', () => {
+            let unit;
+
+            beforeEach(() =>{
+                unit = 'some unit';
+                dataset = aTestDataSet()
+                            .withFivePlusOther()
+                            .build();
+                legendChart = legend();
+
+                legendChart.unit(unit);
+
+                // DOM Fixture Setup
+                f = jasmine.getFixtures();
+                f.fixturesPath = 'base/test/fixtures/';
+                f.load('testContainer.html');
+
+                containerFixture = d3.select('.test-container');
+                containerFixture.datum(dataset).call(legendChart);
+            });
+
+            afterEach(() =>{
+                containerFixture.remove();
+                f = jasmine.getFixtures();
+                f.cleanUp();
+                f.clearCache();
+            });
+
+            it('should add the proper value with unit to each value element', () => {
+                let texts = containerFixture
+                        .select('.britechart-legend')
+                        .selectAll('.legend-entry-value text'),
+                    elements = texts[0];
+
+                texts.each(function(d, index) {
+                    expect(elements[index]).toEqual(dataset[index]['quantity'] + unit);
                 });
             });
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add possibility to precise the unit of the values in legend.

## Description
<!--- Describe your changes in detail -->
Add an option to precise the unit of the data represented 
`new Legend().unit(' apple')`

--> `My topic` `151 apple`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
