### PR TITLE
Added ESlint task to webpack for demos and added critical rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,6 +42,9 @@
         "wrap-iife": [2, "inside"]
     }, 
     "parserOptions": {
-       "sourceType": "module"
+       "sourceType": "module",
+       "ecmaFeatures": {
+           "experimentalObjectRestSpread": true
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "base-64": "^0.1.0",
     "d3": "^4.10.0",
+    "eslint-loader": "^1.9.0",
     "lodash.assign": "^4.2.0"
   },
   "devDependencies": {

--- a/src/charts/helpers/exportChart.js
+++ b/src/charts/helpers/exportChart.js
@@ -146,7 +146,7 @@ define(function(require) {
      */
     function formatHtmlByBrowser(html) {
         if (navigator.userAgent.search('FireFox') > -1) {
-            return html.replace(/url.*&quot;\)/, `url(&quot;linearGradient[id*="-gradient-"]&quot;);`);
+            return html.replace(/url.*&quot;\)/, 'url(&quot;linearGradient[id*="-gradient-"]&quot;);');
         }
 
         return html;

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -229,6 +229,7 @@ define(function(require){
                 'customMouseMove',
                 'customDataEntryClick'
             );
+
         /**
          * This function creates the graph using the selection and data provided
          *

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,7 +71,7 @@ var webpack = require('webpack'),
     lintJSLoader = {
         test: /\.js?$/,
         include: path.resolve(__dirname, './src/charts'),
-        exclude: /(node_modules|__tests__|tests_index.js)/,
+        exclude: /(node_modules)/,
         enforce: 'pre',
         loader: 'eslint-loader'
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,14 @@ var webpack = require('webpack'),
                 presets: ['es2015', 'stage-0'],
                 cacheDirectory: true,
             },
-    }],
+        }],
+    },
+    lintJSLoader = {
+        test: /\.js?$/,
+        include: path.resolve(__dirname, './src/charts'),
+        exclude: /(node_modules|__tests__|tests_index.js)/,
+        enforce: 'pre',
+        loader: 'eslint-loader'
     },
 
     plugins = [
@@ -109,7 +116,10 @@ const getConfig = (env) => {
                 modules: [__dirname, 'node_modules'],
             },
             module: {
-                rules: [defaultJSLoader],
+                rules: [
+                    defaultJSLoader,
+                    lintJSLoader
+                ],
             },
             plugins : [
                 commonsPlugin

--- a/yarn.lock
+++ b/yarn.lock
@@ -2676,6 +2676,16 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-loader@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-1.9.0.tgz#7e1be9feddca328d3dcfaef1ad49d5beffe83a13"
+  dependencies:
+    loader-fs-cache "^1.0.0"
+    loader-utils "^1.0.2"
+    object-assign "^4.0.1"
+    object-hash "^1.1.4"
+    rimraf "^2.6.1"
+
 eslint@^2.7.0:
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-2.13.1.tgz#e4cc8fa0f009fb829aaae23855a29360be1f6c11"
@@ -2964,6 +2974,14 @@ finalhandler@1.0.4, finalhandler@~1.0.4:
     parseurl "~1.3.1"
     statuses "~1.3.1"
     unpipe "~1.0.0"
+
+find-cache-dir@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
+  dependencies:
+    commondir "^1.0.1"
+    mkdirp "^0.5.1"
+    pkg-dir "^1.0.0"
 
 find-cache-dir@^1.0.0:
   version "1.0.0"
@@ -4502,6 +4520,13 @@ load-json-file@^2.0.0:
     pify "^2.0.0"
     strip-bom "^3.0.0"
 
+loader-fs-cache@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz#56e0bf08bd9708b26a765b68509840c8dec9fdbc"
+  dependencies:
+    find-cache-dir "^0.1.1"
+    mkdirp "0.5.1"
+
 loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
@@ -4913,7 +4938,7 @@ mkdirp@0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -5246,6 +5271,10 @@ object-assign@^4.0.1, object-assign@^4.1.0:
 object-component@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
+
+object-hash@^1.1.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.2.0.tgz#e96af0e96981996a1d47f88ead8f74f1ebc4422b"
 
 object-keys@^1.0.8:
   version "1.0.11"
@@ -5585,6 +5614,12 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
 
 pkg-dir@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Just like it's done in `britecharts-react`, added a task in Webpack to run ESlint rule before serving the demos. This will allow contributors to track the style guide that will keep codebase consistent.

## Description
<!--- Describe your changes in detail -->
* Added a new object `lintJSLoader` that serves as an additional rule to the set of `demos` tasks.
* Fixed ESlint errors that were identified after running the task (screenshot attached).
* Added new ESlint rule that supports spread operator ([more info](https://github.com/eslint/eslint/issues/2532)).

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/390

## How Has This Been Tested?
Ran tests.

## Screenshots (if appropriate):
Running `yarn demos:serve` returns this if there is ESlint error:
<img width="1421" alt="screen shot 2018-01-29 at 11 09 46 pm" src="https://user-images.githubusercontent.com/9118852/35553385-930f6530-054c-11e8-80a3-25de70cc0197.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
