### PR TITLE
Feature - added text formatter function to Donut's API

### DIFF
--- a/demos/demo-donut.js
+++ b/demos/demo-donut.js
@@ -41,6 +41,9 @@ function createDonutChart(optionalColorSchema) {
             .height(containerWidth)
             .externalRadius(containerWidth/2.5)
             .internalRadius(containerWidth/5)
+            .centeredTextFunction((d) => {
+                return `${d.quantity} ${d.name}`;
+            })
             .on('customMouseOver', function(data) {
                 legendChart.highlight(data.data.id);
             })

--- a/demos/demo-donut.js
+++ b/demos/demo-donut.js
@@ -41,9 +41,6 @@ function createDonutChart(optionalColorSchema) {
             .height(containerWidth)
             .externalRadius(containerWidth/2.5)
             .internalRadius(containerWidth/5)
-            .centeredTextFunction((d) => {
-                return `${d.quantity} ${d.name}`;
-            })
             .on('customMouseOver', function(data) {
                 legendChart.highlight(data.data.id);
             })

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -558,6 +558,13 @@ define(function(require) {
 
         // API
 
+        /**
+         * Gets or Sets the centeredTextFunction of the chart. If function is provided
+         * the format will follow the custom function's value format.
+         * @param  {Function} _x        Custom function that returns a formatted string
+         * @return {Function | module}  Current centeredTextFunction or Chart module to chain calls
+         * @public
+         */
         exports.centeredTextFunction = function(_x) {
             if (!arguments.length) {
                 return centeredTextFunction;

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -561,6 +561,8 @@ define(function(require) {
         /**
          * Gets or Sets the centeredTextFunction of the chart. If function is provided
          * the format will be changed by the custom function's value format.
+         * The default format function value is "${d.percentage}% ${d.name}"
+         * The callback will provide the data object with id, name, percentage, and quantity
          * @param  {Function} _x        Custom function that returns a formatted string
          * @return {Function | module}  Current centeredTextFunction or Chart module to chain calls
          * @public

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -112,7 +112,7 @@ define(function(require) {
             colorScale,
             colorSchema = colorHelper.colorSchemas.britecharts,
 
-            centeredTextFunction = (data) => `${data.percentage}% ${data.name}`,
+            centeredTextFunction = (d) => `${d.percentage}% ${d.name}`,
 
             // utils
             storeAngle = function(d) {

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -561,11 +561,13 @@ define(function(require) {
         /**
          * Gets or Sets the centeredTextFunction of the chart. If function is provided
          * the format will be changed by the custom function's value format.
-         * The default format function value is "${d.percentage}% ${d.name}"
-         * The callback will provide the data object with id, name, percentage, and quantity
+         * The default format function value is "${d.percentage}% ${d.name}".
+         * The callback will provide the data object with id, name, percentage, and quantity.
+         * Also provides the component added by the user in each data entry.
          * @param  {Function} _x        Custom function that returns a formatted string
          * @return {Function | module}  Current centeredTextFunction or Chart module to chain calls
          * @public
+         * @example donutChart.centeredTextFunction(d => `${d.id} ${d.quantity}`)
          */
         exports.centeredTextFunction = function(_x) {
             if (!arguments.length) {

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -112,6 +112,8 @@ define(function(require) {
             colorScale,
             colorSchema = colorHelper.colorSchemas.britecharts,
 
+            centeredTextFunction = (data) => `${data.percentage}% ${data.name}`,
+
             // utils
             storeAngle = function(d) {
                 this._current = d;
@@ -321,7 +323,7 @@ define(function(require) {
             if (obj.data) {
 
                 svg.select('.donut-text')
-                    .text(() => `${obj.data.percentage}% ${obj.data.name}`)
+                    .text(() => centeredTextFunction(obj.data))
                     .attr('dy', '.2em')
                     .attr('text-anchor', 'middle');
 
@@ -555,6 +557,15 @@ define(function(require) {
 
 
         // API
+
+        exports.centeredTextFunction = function(_x) {
+            if (!arguments.length) {
+                return centeredTextFunction;
+            }
+            centeredTextFunction = _x;
+
+            return this;
+        }
 
         /**
          * Gets or Sets the colorSchema of the chart

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -560,7 +560,7 @@ define(function(require) {
 
         /**
          * Gets or Sets the centeredTextFunction of the chart. If function is provided
-         * the format will follow the custom function's value format.
+         * the format will be changed by the custom function's value format.
          * @param  {Function} _x        Custom function that returns a formatted string
          * @return {Function | module}  Current centeredTextFunction or Chart module to chain calls
          * @public

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -292,27 +292,46 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                 });
             });
 
-            describe('when centeredTextFunction is called', () => {
-                it('the default function formats text properly', () => {
-                    let actual,
-                        expected = 'something something',
+            describe('when centeredTextFunction', () => {
+                it('is not called, the default function formats text properly', () => {
+                    let actualLabel,
+                        actualValue,
+                        expectedLabel = 'Shiny',
+                        expectedValue = '20%',
                         dataset = buildDataSet('withThreeCategories');
 
-                    donutChart.centeredTextFunction();
+                    donutChart.highlightSliceById(11);
                     containerFixture.datum(dataset).call(donutChart);
 
-                    let firstSlice = containerFixture.select('.chart-group .arc path');
+                    let valueNode = containerFixture.select('text.donut-text .value').nodes()[0];
+                    let labelNode = containerFixture.select('text.donut-text .label').nodes()[0];
 
-                    donutChart.on('customMouseOver', () => {});
-                    firstSlice.dispatch('mouseover');
+                    actualValue = d3.select(valueNode).text();
+                    actualLabel = d3.select(labelNode).text();
 
-                    console.log('**actual nodes', containerFixture);
+                    expect(actualValue).toBe(expectedValue);
+                    expect(actualLabel).toBe(expectedLabel);
+                });
 
-                    let nodes = containerFixture.select('text.donut-text').nodes();
+                it('is called, the custom function changes text format properly', () => {
+                    let actualLabel,
+                        actualValue,
+                        expectedLabel = '200',
+                        expectedValue = '11',
+                        dataset = buildDataSet('withThreeCategories');
 
-                    // actual = d3.select(textNodes[0].text());
+                    donutChart.centeredTextFunction((d) => `${d.id} ${d.quantity}`);
+                    donutChart.highlightSliceById(11);
+                    containerFixture.datum(dataset).call(donutChart);
 
-                    expect(false).toBe(true);
+                    let valueNode = containerFixture.select('text.donut-text .value').nodes()[0];
+                    let labelNode = containerFixture.select('text.donut-text .label').nodes()[0];
+
+                    actualValue = d3.select(valueNode).text();
+                    actualLabel = d3.select(labelNode).text();
+
+                    expect(actualValue).toBe(expectedValue);
+                    expect(actualLabel).toBe(expectedLabel);
                 });
             });
 

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -293,6 +293,7 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
             });
 
             describe('when centeredTextFunction', () => {
+
                 it('is not called, the default function formats text properly', () => {
                     let actualLabel,
                         actualValue,

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -290,7 +290,31 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
 
                     expect(actual).toBe(expected);
                 });
-            })
+            });
+
+            describe('when centeredTextFunction is called', () => {
+                it('the default function formats text properly', () => {
+                    let actual,
+                        expected = 'something something',
+                        dataset = buildDataSet('withThreeCategories');
+
+                    donutChart.centeredTextFunction();
+                    containerFixture.datum(dataset).call(donutChart);
+
+                    let firstSlice = containerFixture.select('.chart-group .arc path');
+
+                    donutChart.on('customMouseOver', () => {});
+                    firstSlice.dispatch('mouseover');
+
+                    console.log('**actual nodes', containerFixture);
+
+                    let nodes = containerFixture.select('text.donut-text').nodes();
+
+                    // actual = d3.select(textNodes[0].text());
+
+                    expect(false).toBe(true);
+                });
+            });
 
             describe('API', function() {
 
@@ -440,7 +464,7 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                     expect(actual).toBe(expected);
                 });
 
-                it('should not have numberFormat by default', () =>{
+                it('should not have numberFormat by default', () => {
                     let expected = undefined,
                         actual;
 
@@ -449,7 +473,7 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                     expect(expected).toBe(actual);
                 });
 
-                it('should provide numberFormat getter and setter', () =>{
+                it('should provide numberFormat getter and setter', () => {
                     let previous = donutChart.numberFormat(),
                         expected = 'd',
                         actual;


### PR DESCRIPTION
## Description
This feature allows user to customize the format of the text shown in the middle of the chart on hover. If the user wants to show quantity instead of percentage, this function can be used to do that.

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/481

## How Has This Been Tested?
Added new tests to `donut.spec.js` that checks:
* whether the default function is properly applied and correct value is returned
* if the function is applied, validate that the new format values are matching the expected 

## Screenshots (if appropriate):
Screenshot of the format that takes in `quantity` as a value and `name` as label.
![centeredtextformat](https://user-images.githubusercontent.com/31934144/35609449-3389c17a-0612-11e8-8a92-b3f0853a5a0a.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
