### PR TITLE
Feat stacks reverse

### DIFF
--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -111,7 +111,7 @@ define(function(require){
             transformedData,
             stacks,
             layerElements,
-            reverseStacks = false,
+            hasReversedStacks = false,
 
             tooltipThreshold = 480,
 
@@ -694,7 +694,7 @@ define(function(require){
         function prepareData(data) {
             stacks = uniq(data.map(({stack}) => stack));
 
-            if (reverseStacks) {
+            if (hasReversedStacks) {
                 stacks = stacks.reverse();
             }
 
@@ -874,16 +874,16 @@ define(function(require){
         };
 
         /**
-        * Gets or Sets the reverseStacks property of the chart, it reverse the stacks order.
+        * Gets or Sets the hasReversedStacks property of the chart, it reverse the stacks order.
          * @param  {boolean} _x Desired horizontal direction for the graph
-         * @return { reverseStacks | module} If it is horizontal or Bar Chart module to chain calls
+         * @return { hasReversedStacks | module} If it is horizontal or Bar Chart module to chain calls
          * @public
          */
-        exports.reverseStacks = function(_x) {
+        exports.hasReversedStacks = function(_x) {
             if (!arguments.length) {
-                return reverseStacks;
+                return hasReversedStacks;
             }
-            reverseStacks = _x;
+            hasReversedStacks = _x;
 
             return this;
         };

--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -874,9 +874,9 @@ define(function(require){
         };
 
         /**
-        * Gets or Sets the hasReversedStacks property of the chart, it reverse the stacks order.
-         * @param  {boolean} _x Desired horizontal direction for the graph
-         * @return { hasReversedStacks | module} If it is horizontal or Bar Chart module to chain calls
+         * Gets or Sets the hasReversedStacks property of the chart, reversing the order of stacks.
+         * @param  {boolean} _x Desired hasReversedStacks flag
+         * @return { hasReversedStacks | module} Current hasReversedStacks or Chart module to chain calls
          * @public
          */
         exports.hasReversedStacks = function(_x) {

--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -111,6 +111,7 @@ define(function(require){
             transformedData,
             stacks,
             layerElements,
+            reverseStacks = false,
 
             tooltipThreshold = 480,
 
@@ -692,6 +693,11 @@ define(function(require){
          */
         function prepareData(data) {
             stacks = uniq(data.map(({stack}) => stack));
+
+            if (reverseStacks) {
+                stacks = stacks.reverse();
+            }
+
             transformedData = d3Collection.nest()
                 .key(getName)
                 .rollup(function(values) {
@@ -863,6 +869,21 @@ define(function(require){
                 return isHorizontal;
             }
             isHorizontal = _x;
+
+            return this;
+        };
+
+        /**
+        * Gets or Sets the reverseStacks property of the chart, it reverse the stacks order.
+         * @param  {boolean} _x Desired horizontal direction for the graph
+         * @return { reverseStacks | module} If it is horizontal or Bar Chart module to chain calls
+         * @public
+         */
+        exports.reverseStacks = function(_x) {
+            if (!arguments.length) {
+                return reverseStacks;
+            }
+            reverseStacks = _x;
 
             return this;
         };

--- a/test/specs/stacked-bar.spec.js
+++ b/test/specs/stacked-bar.spec.js
@@ -210,6 +210,18 @@ define(['d3', 'stacked-bar', 'stackedBarDataBuilder'], function(d3, chart, dataB
                 expect(actual).toBe(expected);
             });
 
+            it('should provide reverseStacks getter and setter', () => {
+                let previous = stackedBarChart.reverseStacks(),
+                    expected = true,
+                    actual;
+
+                stackedBarChart.reverseStacks(expected);
+                actual = stackedBarChart.reverseStacks();
+
+                expect(previous).not.toBe(actual);
+                expect(actual).toBe(expected);
+            });
+
             it('should provide isAnimated getter and setter', () => {
                 let previous = stackedBarChart.isAnimated(),
                     expected = true,

--- a/test/specs/stacked-bar.spec.js
+++ b/test/specs/stacked-bar.spec.js
@@ -210,13 +210,13 @@ define(['d3', 'stacked-bar', 'stackedBarDataBuilder'], function(d3, chart, dataB
                 expect(actual).toBe(expected);
             });
 
-            it('should provide reverseStacks getter and setter', () => {
-                let previous = stackedBarChart.reverseStacks(),
+            it('should provide hasReversedStacks getter and setter', () => {
+                let previous = stackedBarChart.hasReversedStacks(),
                     expected = true,
                     actual;
 
-                stackedBarChart.reverseStacks(expected);
-                actual = stackedBarChart.reverseStacks();
+                stackedBarChart.hasReversedStacks(expected);
+                actual = stackedBarChart.hasReversedStacks();
 
                 expect(previous).not.toBe(actual);
                 expect(actual).toBe(expected);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add an option to reverse stack order

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In vertical mode reverse stacks allow to have the tooltip legend in the same order as the stacks of the charts
In horizontal mode it's better to have stacks in default order.
I didn't want to change the default behavior & change stacks order for everyone, maybe someone code something to have a precise order for stacks


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
yarn test -> ok
Works with the demos

## Screenshots (if appropriate):
![35743261-59006ada-083d-11e8-8c3f-bca568c2b62d](https://user-images.githubusercontent.com/31934144/35748790-16a15e08-0804-11e8-807e-e15c7ae4433a.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
