### PR TITLE
Feature - allow ability to switch Bar's hover behavior

### DIFF
--- a/demos/demo-bar.js
+++ b/demos/demo-bar.js
@@ -52,7 +52,6 @@ function createHorizontalBarChart() {
                 top: 20,
                 bottom: 30
             })
-            .hasSingleHover(false)
             .colorSchema(colors.colorSchemas.britecharts)
             .width(containerWidth)
             .yAxisPaddingBetweenChart(30)

--- a/demos/demo-bar.js
+++ b/demos/demo-bar.js
@@ -52,6 +52,7 @@ function createHorizontalBarChart() {
                 top: 20,
                 bottom: 30
             })
+            .hasSingleHover(false)
             .colorSchema(colors.colorSchemas.britecharts)
             .width(containerWidth)
             .yAxisPaddingBetweenChart(30)

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -765,7 +765,7 @@ define(function(require) {
          * If the value is true (default), the only the hovered bar
          * will switch to darker color. If the value is false, only the hovered bar will stay
          * the same while the rest of the bars will switch to darker colors.
-         * @param  {boolean} _x        Should darken the hovered bar
+         * @param  {boolean} _x        Should highlight the hovered bar
          * @return { boolean | module} Is hasSingleBarHighlight used or Chart module to chain calls
          * @public
          */

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -98,6 +98,7 @@ define(function(require) {
             isHorizontal = false,
             svg,
 
+            hasSingleHover = true,
             isAnimated = false,
             ease = d3Ease.easeQuadInOut,
             animationDuration = 800,
@@ -348,14 +349,14 @@ define(function(require) {
                 .attr('x', 0)
                 .attr('height', yScale.bandwidth())
                 .attr('width', ({value}) => xScale(value))
-                .on('mouseover', function(d) {
-                    handleMouseOver(this, d, chartWidth, chartHeight);
+                .on('mouseover', function(d, index, barList) {
+                    handleMouseOver(this, d, barList, chartWidth, chartHeight);
                 })
                 .on('mousemove', function(d) {
                     handleMouseMove(this, d, chartWidth, chartHeight);
                 })
-                .on('mouseout', function(d) {
-                    handleMouseOut(this, d, chartWidth, chartHeight);
+                .on('mouseout', function(d, index, barList) {
+                    handleMouseOut(this, d, barList, chartWidth, chartHeight);
                 })
                 .on('click', function(d) {
                     handleClick(this, d, chartWidth, chartHeight);
@@ -382,14 +383,14 @@ define(function(require) {
                 .attr('y', chartHeight)
                 .attr('height', yScale.bandwidth())
                 .attr('width', ({value}) => xScale(value))
-                .on('mouseover', function(d) {
-                    handleMouseOver(this, d, chartWidth, chartHeight);
+                .on('mouseover', function(d, index, barList) {
+                    handleMouseOver(this, d, barList, chartWidth, chartHeight);
                 })
                 .on('mousemove', function(d) {
                     handleMouseMove(this, d, chartWidth, chartHeight);
                 })
-                .on('mouseout', function(d) {
-                    handleMouseOut(this, d, chartWidth, chartHeight);
+                .on('mouseout', function(d, index, barList) {
+                    handleMouseOut(this, d, barList, chartWidth, chartHeight);
                 })
                 .on('click', function(d) {
                     handleClick(this, d, chartWidth, chartHeight);
@@ -421,14 +422,14 @@ define(function(require) {
                 .attr('y', ({value}) => yScale(value))
                 .attr('width', xScale.bandwidth())
                 .attr('height', ({value}) => chartHeight - yScale(value))
-                .on('mouseover', function(d) {
-                    handleMouseOver(this, d, chartWidth, chartHeight);
+                .on('mouseover', function(d, index, barList) {
+                    handleMouseOver(this, d, barList, chartWidth, chartHeight);
                 })
                 .on('mousemove', function(d) {
                     handleMouseMove(this, d, chartWidth, chartHeight);
                 })
-                .on('mouseout', function(d) {
-                    handleMouseOut(this, d, chartWidth, chartHeight);
+                .on('mouseout', function(d, index, barList) {
+                    handleMouseOut(this, d, barList, chartWidth, chartHeight);
                 })
                 .on('click', function(d) {
                     handleClick(this, d, chartWidth, chartHeight);
@@ -459,14 +460,14 @@ define(function(require) {
                 .attr('y', ({value}) => yScale(value))
                 .attr('width', xScale.bandwidth())
                 .attr('height', ({value}) => chartHeight - yScale(value))
-                .on('mouseover', function(d) {
-                    handleMouseOver(this, d, chartWidth, chartHeight);
+                .on('mouseover', function(d, index, barList) {
+                    handleMouseOver(this, d, barList, chartWidth, chartHeight);
                 })
                 .on('mousemove', function(d) {
                     handleMouseMove(this, d, chartWidth, chartHeight);
                 })
-                .on('mouseout', function(d) {
-                    handleMouseOut(this, d, chartWidth, chartHeight);
+                .on('mouseout', function(d, index, barList) {
+                    handleMouseOut(this, d, barList, chartWidth, chartHeight);
                 })
                 .on('click', function(d) {
                     handleClick(this, d, chartWidth, chartHeight);
@@ -637,9 +638,20 @@ define(function(require) {
          * @return {void}
          * @private
          */
-        function handleMouseOver(e, d, chartWidth, chartHeight) {
+        function handleMouseOver(e, d, barList, chartWidth, chartHeight) {
             dispatcher.call('customMouseOver', e, d, d3Selection.mouse(e), [chartWidth, chartHeight]);
-            d3Selection.select(e).attr('fill', ({name}) => d3Color.color(colorMap(name)).darker());
+
+            if (hasSingleHover) {
+                d3Selection.select(e).attr('fill', ({name}) => d3Color.color(colorMap(name)).darker());
+                return;
+            }
+
+            barList.forEach(barRect => {
+                if (barRect === e) {
+                    return;
+                }
+                d3Selection.select(barRect).attr('fill', ({name}) => d3Color.color(colorMap(name)).darker());
+            });
         }
 
         /**
@@ -656,9 +668,12 @@ define(function(require) {
          * @return {void}
          * @private
          */
-        function handleMouseOut(e, d, chartWidth, chartHeight) {
+        function handleMouseOut(e, d, barList, chartWidth, chartHeight) {
             dispatcher.call('customMouseOut', e, d, d3Selection.mouse(e), [chartWidth, chartHeight]);
-            d3Selection.select(e).attr('fill', ({name}) => colorMap(name));
+
+            barList.forEach((barRect) => {
+                d3Selection.select(barRect).attr('fill', ({name}) => colorMap(name));
+            });
         }
 
         /**
@@ -933,6 +948,15 @@ define(function(require) {
                 return orderingFunction;
             }
             orderingFunction = _x;
+
+            return this;
+        }
+
+        exports.hasSingleHover = function(_x) {
+            if (!arguments.length) {
+                return hasSingleHover;
+            }
+            hasSingleHover = _x;
 
             return this;
         }

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -98,7 +98,7 @@ define(function(require) {
             isHorizontal = false,
             svg,
 
-            hasSingleHover = true,
+            hasSingleBarHighlight = true,
             isAnimated = false,
             ease = d3Ease.easeQuadInOut,
             animationDuration = 800,
@@ -641,7 +641,7 @@ define(function(require) {
         function handleMouseOver(e, d, barList, chartWidth, chartHeight) {
             dispatcher.call('customMouseOver', e, d, d3Selection.mouse(e), [chartWidth, chartHeight]);
 
-            if (hasSingleHover) {
+            if (hasSingleBarHighlight) {
                 d3Selection.select(e).attr('fill', ({name}) => d3Color.color(colorMap(name)).darker());
                 return;
             }
@@ -761,19 +761,19 @@ define(function(require) {
         };
 
         /**
-         * Gets or Sets the hasSingleHover status.
+         * Gets or Sets the hasSingleBarHighlight status.
          * If the value is true (default), the only the hovered bar
          * will switch to darker color. If the value is false, only the hovered bar will stay
          * the same while the rest of the bars will switch to darker colors.
-         * @param  {boolean} _x     Should darken the hovered bar
-         * @return { boolean | module} Is hasSingleHover used or Chart module to chain calls
+         * @param  {boolean} _x        Should darken the hovered bar
+         * @return { boolean | module} Is hasSingleBarHighlight used or Chart module to chain calls
          * @public
          */
-        exports.hasSingleHover = function(_x) {
+        exports.hasSingleBarHighlight = function(_x) {
             if (!arguments.length) {
-                return hasSingleHover;
+                return hasSingleBarHighlight;
             }
-            hasSingleHover = _x;
+            hasSingleBarHighlight = _x;
 
             return this;
         }

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -742,6 +742,43 @@ define(function(require) {
         };
 
         /**
+         * Gets or Sets the hasPercentage status
+         * @param  {boolean} _x     Should use percentage as value format
+         * @return { boolean | module} Is percentage used or Chart module to chain calls
+         * @public
+         */
+        exports.hasPercentage = function(_x) {
+            if (!arguments.length) {
+                return numberFormat === PERCENTAGE_FORMAT;
+            }
+            if (_x) {
+                numberFormat = PERCENTAGE_FORMAT;
+            } else {
+                numberFormat = NUMBER_FORMAT;
+            }
+
+            return this;
+        };
+
+        /**
+         * Gets or Sets the hasSingleHover status.
+         * If the value is true (default), the only the hovered bar
+         * will switch to darker color. If the value is false, only the hovered bar will stay
+         * the same while the rest of the bars will switch to darker colors.
+         * @param  {boolean} _x     Should darken the hovered bar
+         * @return { boolean | module} Is hasSingleHover used or Chart module to chain calls
+         * @public
+         */
+        exports.hasSingleHover = function(_x) {
+            if (!arguments.length) {
+                return hasSingleHover;
+            }
+            hasSingleHover = _x;
+
+            return this;
+        }
+
+        /**
          * Gets or Sets the height of the chart
          * @param  {number} _x Desired width for the graph
          * @return { height | module} Current height or Chart module to chain calls
@@ -951,34 +988,6 @@ define(function(require) {
 
             return this;
         }
-
-        exports.hasSingleHover = function(_x) {
-            if (!arguments.length) {
-                return hasSingleHover;
-            }
-            hasSingleHover = _x;
-
-            return this;
-        }
-
-        /**
-         * Gets or Sets the hasPercentage status
-         * @param  {boolean} _x     Should use percentage as value format
-         * @return { boolean | module} Is percentage used or Chart module to chain calls
-         * @public
-         */
-        exports.hasPercentage = function(_x) {
-            if (!arguments.length) {
-                return numberFormat === PERCENTAGE_FORMAT;
-            }
-            if (_x) {
-                numberFormat = PERCENTAGE_FORMAT;
-            } else {
-                numberFormat = NUMBER_FORMAT;
-            }
-
-            return this;
-        };
 
         /**
          * Gets or Sets the valueLabel of the chart

--- a/test/specs/bar.spec.js
+++ b/test/specs/bar.spec.js
@@ -123,14 +123,14 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
             });
         });
 
-        describe('when hasSingleHover is called', () => {
+        describe('when hasSingleBarHighlight is called', () => {
 
             it('should darken the original color of the hovered bar', () => {
-                let expectedHasHover = true;
+                let expectedHasBarHighlight = true;
                 let expectedColor = '#7bdcc0';
                 let expectedHoverColor = 'rgb(86, 154, 134)';
 
-                let actualHasHover = barChart.hasSingleHover();
+                let actualHasHover = barChart.hasSingleBarHighlight();
                 let bar = containerFixture.selectAll('.bar:nth-child(1)');
 
                 let actualColor = bar.attr('fill');
@@ -138,24 +138,24 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
                 bar.dispatch('mouseover');
                 let actualHoverColor = bar.attr('fill');
 
-                expect(actualHasHover).toBe(expectedHasHover);
+                expect(actualHasHover).toBe(expectedHasBarHighlight);
                 expect(actualColor).toBe(expectedColor);
                 expect(actualHoverColor).toBe(expectedHoverColor);
             });
 
             it('should keep the same hover color of the hovered bar', () => {
-                let expectedHasHover = false;
+                let expectedHasBarHighlight = false;
                 let expectedColor = '#7bdcc0';
 
-                barChart.hasSingleHover(false);
-                let actualHasHover = barChart.hasSingleHover();
+                barChart.hasSingleBarHighlight(false);
+                let actualHasHover = barChart.hasSingleBarHighlight();
                 let bar = containerFixture.selectAll('.bar:nth-child(1)');
                 let actualColor = bar.attr('fill');
 
                 bar.dispatch('mouseover');
                 let hoverColor = bar.attr('fill');
 
-                expect(actualHasHover).toBe(expectedHasHover);
+                expect(actualHasHover).toBe(expectedHasBarHighlight);
                 expect(actualColor).toBe(expectedColor);
                 expect(actualColor).toBe(hoverColor);
             });
@@ -434,13 +434,13 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
                 expect(actual).toBe(expected);
             });
 
-            it('should provide hasSingleHover getter and setter', () =>{
-                let previous = barChart.hasSingleHover(),
+            it('should provide hasSingleBarHighlight getter and setter', () =>{
+                let previous = barChart.hasSingleBarHighlight(),
                     expected = false,
                     actual;
 
-                barChart.hasSingleHover(expected);
-                actual = barChart.hasSingleHover();
+                barChart.hasSingleBarHighlight(expected);
+                actual = barChart.hasSingleBarHighlight();
 
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);

--- a/test/specs/bar.spec.js
+++ b/test/specs/bar.spec.js
@@ -91,10 +91,10 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
         describe('when orderingFunction is called', () => {
 
             it('accepts custom descending order function', () => {
-                let fn = (a, b) => b.value - a.value; 
+                let fn = (a, b) => b.value - a.value;
                 let actual,
                     expected = {
-                        name: 'E', 
+                        name: 'E',
                         value: 0.12702
                     };
 
@@ -121,7 +121,45 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
                 expect(actual.name).toBe(expected.name);
                 expect(actual.value).toBe(expected.value);
             });
-        })
+        });
+
+        describe('when hasSingleHover is called', () => {
+
+            it('should darken the original color of the hovered bar', () => {
+                let expectedHasHover = true;
+                let expectedColor = '#7bdcc0';
+                let expectedHoverColor = 'rgb(86, 154, 134)';
+
+                let actualHasHover = barChart.hasSingleHover();
+                let bar = containerFixture.selectAll('.bar:nth-child(1)');
+
+                let actualColor = bar.attr('fill');
+
+                bar.dispatch('mouseover');
+                let actualHoverColor = bar.attr('fill');
+
+                expect(actualHasHover).toBe(expectedHasHover);
+                expect(actualColor).toBe(expectedColor);
+                expect(actualHoverColor).toBe(expectedHoverColor);
+            });
+
+            it('should keep the same hover color of the hovered bar', () => {
+                let expectedHasHover = false;
+                let expectedColor = '#7bdcc0';
+
+                barChart.hasSingleHover(false);
+                let actualHasHover = barChart.hasSingleHover();
+                let bar = containerFixture.selectAll('.bar:nth-child(1)');
+                let actualColor = bar.attr('fill');
+
+                bar.dispatch('mouseover');
+                let hoverColor = bar.attr('fill');
+
+                expect(actualHasHover).toBe(expectedHasHover);
+                expect(actualColor).toBe(expectedColor);
+                expect(actualColor).toBe(hoverColor);
+            });
+        });
 
         describe('API', function() {
 

--- a/test/specs/bar.spec.js
+++ b/test/specs/bar.spec.js
@@ -395,6 +395,18 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);
             });
+
+            it('should provide hasSingleHover getter and setter', () =>{
+                let previous = barChart.hasSingleHover(),
+                    expected = false,
+                    actual;
+
+                barChart.hasSingleHover(expected);
+                actual = barChart.hasSingleHover();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
         });
 
         describe('when clicking on a bar', function() {

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -431,11 +431,6 @@ define([
                         expected = 2,
                         actual;
 
-                it('should provide a xTicks getter and setter', () => {
-                    let previous = lineChart.xTicks(),
-                        expected = 2,
-                        actual;
-
                     lineChart.xTicks(expected);
                     actual = lineChart.xTicks();
 
@@ -731,4 +726,3 @@ define([
             });
         });
     });
-});


### PR DESCRIPTION
Added a new feature that allows the user to be able to set the `hover` behavior over bar chart. 

## Description
Added a new function to `Bar`'s API called `hasSingleHover` which accepts a boolean value. 
* If `hasSingleHover` is not called (the default value is `true`), the behavior of the hover mode behaves as default: if one hovers over a bar, the hovered bar is darkened while the rest stay the same.
* If `hasSingleHover` is set to `false`, on hovering the bar all the bars but the hovered one will darken instead (the opposite).

## Motivation and Context
This feature will allow the user to choose between different bar hover behavior based on the one that makes sense. I saw this issue https://github.com/eventbrite/britecharts/issues/485 which gave me an idea of making it configurable.

## How Has This Been Tested?
Added 3 new tests to `bar.spec.js`:
1) One that checks setter and getter of `hasSingleHover`
2) Checks if the default behavior (color switch on hover) stays the same as before.
3) When `hasSingleHover(false)` check that the color of the hovered bar stays the same (since others are darkened).

## Screenshots (if appropriate):
* `hasSingleHover(false)` - only the hovered bar kept its color while others are darkened
![togglehoverdark](https://user-images.githubusercontent.com/31934144/35661768-3457fb5a-06c9-11e8-96f3-8a19c12232a0.png)
*  `hasSingleHover()` - by default returns `true`, in this case the behavior is the same as before.
![screen shot 2018-01-31 at 8 58 40 pm](https://user-images.githubusercontent.com/31934144/35661821-921572cc-06c9-11e8-93c1-771c563a7ae6.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Update:** Renamed function to `hasSingleBarHighlight`