### PR TITLE
Eased compilation requirement for ESlint and updated CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
-2.4.12
+2.4.12 - Minor
+--------------
+* Added ESlint task to webpack for demos and added critical rules (dalerasrorov-eb)
+* Eliminated mutation of data in cleanData of the Line chart (dalerasrorov-eb)
+* Allow valueFormat to be an empty string  (sound-matt)
+* Feat: add possibility to precise the unit of the values in legend (sound-matt)
+* Fix: stackedbar get nearest datapoint (sound-matt)
+* Fix: stacked-bar no more choosing random color (sound-matt)
+* Stacked bar chart hasPercentage impl (dalerasrorov-eb)
+* Adding anchors to loading states and updating bar demo (Golodhros)
+* Updating changelog (Golodhros)
+* Replace .enablePercentageLabels with .enableLabels (mrbongiolo)
+* Removed .usePercentage for good from BarChart (mrbongiolo)
+* Feature - Added .numberFormat to MiniTooltip (mrbongiolo)
 
 2.4.11 - Minor
 --------------

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,7 +73,11 @@ var webpack = require('webpack'),
         include: path.resolve(__dirname, './src/charts'),
         exclude: /(node_modules)/,
         enforce: 'pre',
-        loader: 'eslint-loader'
+        loader: 'eslint-loader',
+        options: {
+            emitWarning: true,
+            failOnError: false,
+        }
     },
 
     plugins = [
@@ -91,7 +95,7 @@ if (isProduction) {
 
 const commonsPlugin = new webpack.optimize.CommonsChunkPlugin({
     name: 'common',
-    filename: 'common.js', 
+    filename: 'common.js',
     minChunks: Infinity,
 });
 


### PR DESCRIPTION
* While developing, we want to allow devs to be able to debug by putting a `debugger` or `console.log`. Currently, if I put `console.log` to test something, the demos build compilation will fail because and as a result, the console will not appear in the debugger since there ESlint rules that prohibit these things. Because of that, one has to disable the `lintJSLoader` from webpack in order to be able to debug code. I added an option to not fail the build on error but still report the error messages for the developer to check.

* Updated to CHANGELOG to reflect the latest changes since last release update.