### PR TITLE
Feature - new Bar chart API method to accept a custom function for highlighted bars

### DIFF
--- a/demos/demo-bar.js
+++ b/demos/demo-bar.js
@@ -52,6 +52,8 @@ function createHorizontalBarChart() {
                 top: 20,
                 bottom: 30
             })
+            .hasSingleBarHighlight(true)
+            .highlightBarFunction(null)
             .colorSchema(colors.colorSchemas.britecharts)
             .width(containerWidth)
             .yAxisPaddingBetweenChart(30)

--- a/demos/demo-bar.js
+++ b/demos/demo-bar.js
@@ -52,8 +52,6 @@ function createHorizontalBarChart() {
                 top: 20,
                 bottom: 30
             })
-            .hasSingleBarHighlight(true)
-            .highlightBarFunction(null)
             .colorSchema(colors.colorSchemas.britecharts)
             .width(containerWidth)
             .yAxisPaddingBetweenChart(30)

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -765,9 +765,10 @@ define(function(require) {
         /**
          * Gets or Sets the hasSingleBarHighlight status.
          * If the value is true (default), only the hovered bar is considered to
-         * be highlighted and will be switch to darker color. If the value is false,
+         * be highlighted and will be darkened by default. If the value is false,
          * all the bars but the hovered bar are considered to be highlighted
-         * and will switch to darker color.
+         * and will be darkened (by default). To customize the bar highlight or
+         * remove it completely, use highlightBarFunction instead.
          * @param  {boolean} _x        Should highlight the hovered bar
          * @return {boolean | module} Is hasSingleBarHighlight used or Chart module to chain calls
          * @public

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -763,9 +763,10 @@ define(function(require) {
 
         /**
          * Gets or Sets the hasSingleBarHighlight status.
-         * If the value is true (default), the only the hovered bar
-         * will switch to darker color. If the value is false, only the hovered bar will stay
-         * the same while the rest of the bars will switch to darker colors.
+         * If the value is true (default), only the hovered bar is considered to
+         * be highlighted and will be switch to darker color. If the value is false,
+         * all the bars but the hovered bar are considered to be highlighted
+         * and will switch to darker color.
          * @param  {boolean} _x        Should highlight the hovered bar
          * @return { boolean | module} Is hasSingleBarHighlight used or Chart module to chain calls
          * @public
@@ -806,6 +807,7 @@ define(function(require) {
          * @return {highlightBarFunction | module} Is highlightBarFunction used or Chart module to chain calls
          * @public
          * @example barChart.highlightBarFunction(e => d3.select(e).attr('fill', expectedHighlightColor))
+         * @example barChart.highlightBarFunction(e => null) // will disable the default highlight effect
          */
         exports.highlightBarFunction = function(_x) {
             if (!highlightBarFunction.length) {

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -105,7 +105,7 @@ define(function(require) {
             animationStepRatio = 70,
             interBarDelay = (d, i) => animationStepRatio * i,
 
-            highlightBarFunction = (bar) => d3Selection.select(bar).attr('fill', ({name}) => d3Color.color(colorMap(name)).darker()),
+            highlightBarFunction = (barSelection) => barSelection.attr('fill', ({name}) => d3Color.color(colorMap(name)).darker()),
             orderingFunction,
 
             valueLabel = 'value',
@@ -641,9 +641,10 @@ define(function(require) {
          */
         function handleMouseOver(e, d, barList, chartWidth, chartHeight) {
             dispatcher.call('customMouseOver', e, d, d3Selection.mouse(e), [chartWidth, chartHeight]);
+            highlightBarFunction = highlightBarFunction || function() {};
 
             if (hasSingleBarHighlight) {
-                highlightBarFunction(e);
+                highlightBarFunction(d3Selection.select(e));
                 return;
             }
 
@@ -651,7 +652,7 @@ define(function(require) {
                 if (barRect === e) {
                     return;
                 }
-                highlightBarFunction(barRect);
+                highlightBarFunction(d3Selection.select(barRect));
             });
         }
 
@@ -797,7 +798,7 @@ define(function(require) {
 
         /**
          * Gets or Sets the highlightBarFunction function. The callback passed to
-         * this function returns a bar component from the bar chart. Use this function
+         * this function returns a bar selection from the bar chart. Use this function
          * if you want to apply a custom behavior to the highlighted bar on hover.
          * When hasSingleBarHighlight is true the highlighted bar will be the
          * one that was hovered by the user. When hasSingleBarHighlight is false
@@ -806,8 +807,8 @@ define(function(require) {
          * @param  {Function} _x        Desired operation operation on a hovered bar passed through callback
          * @return {highlightBarFunction | module} Is highlightBarFunction used or Chart module to chain calls
          * @public
-         * @example barChart.highlightBarFunction(e => d3.select(e).attr('fill', 'blue'))
-         * barChart.highlightBarFunction(e => null) // will disable the default highlight effect
+         * @example barChart.highlightBarFunction(bar => bar.attr('fill', 'blue'))
+         * barChart.highlightBarFunction(null) // will disable the default highlight effect
          */
         exports.highlightBarFunction = function(_x) {
             if (!highlightBarFunction.length) {

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -745,7 +745,7 @@ define(function(require) {
         /**
          * Gets or Sets the hasPercentage status
          * @param  {boolean} _x     Should use percentage as value format
-         * @return { boolean | module} Is percentage used or Chart module to chain calls
+         * @return {boolean | module} Is percentage used or Chart module to chain calls
          * @public
          */
         exports.hasPercentage = function(_x) {
@@ -768,7 +768,7 @@ define(function(require) {
          * all the bars but the hovered bar are considered to be highlighted
          * and will switch to darker color.
          * @param  {boolean} _x        Should highlight the hovered bar
-         * @return { boolean | module} Is hasSingleBarHighlight used or Chart module to chain calls
+         * @return {boolean | module} Is hasSingleBarHighlight used or Chart module to chain calls
          * @public
          */
         exports.hasSingleBarHighlight = function(_x) {
@@ -783,7 +783,7 @@ define(function(require) {
         /**
          * Gets or Sets the height of the chart
          * @param  {number} _x Desired width for the graph
-         * @return { height | module} Current height or Chart module to chain calls
+         * @return {height | module} Current height or Chart module to chain calls
          * @public
          */
         exports.height = function(_x) {
@@ -806,8 +806,8 @@ define(function(require) {
          * @param  {Function} _x        Desired operation operation on a hovered bar passed through callback
          * @return {highlightBarFunction | module} Is highlightBarFunction used or Chart module to chain calls
          * @public
-         * @example barChart.highlightBarFunction(e => d3.select(e).attr('fill', blue))
-         * @example barChart.highlightBarFunction(e => null) // will disable the default highlight effect
+         * @example barChart.highlightBarFunction(e => d3.select(e).attr('fill', 'blue'))
+         * barChart.highlightBarFunction(e => null) // will disable the default highlight effect
          */
         exports.highlightBarFunction = function(_x) {
             if (!highlightBarFunction.length) {
@@ -823,7 +823,7 @@ define(function(require) {
          * By default this is 'false'
          *
          * @param  {Boolean} _x Desired animation flag
-         * @return { isAnimated | module} Current isAnimated flag or Chart module
+         * @return {isAnimated | module} Current isAnimated flag or Chart module
          * @public
          */
         exports.isAnimated = function(_x) {
@@ -896,7 +896,7 @@ define(function(require) {
         /**
          * Gets or Sets the loading state of the chart
          * @param  {string} markup Desired markup to show when null data
-         * @return { loadingState | module} Current loading state markup or Chart module to chain calls
+         * @return {loadingState | module} Current loading state markup or Chart module to chain calls
          * @public
          */
         exports.loadingState = function(_markup) {
@@ -911,7 +911,7 @@ define(function(require) {
         /**
          * Gets or Sets the margin of the chart
          * @param  {object} _x Margin object to get/set
-         * @return { margin | module} Current margin or Chart module to chain calls
+         * @return {margin | module} Current margin or Chart module to chain calls
          * @public
          */
         exports.margin = function(_x) {
@@ -926,7 +926,7 @@ define(function(require) {
         /**
          * Gets or Sets the nameLabel of the chart
          * @param  {Number} _x Desired nameLabel for the graph
-         * @return { nameLabel | module} Current nameLabel or Chart module to chain calls
+         * @return {nameLabel | module} Current nameLabel or Chart module to chain calls
          * @public
          */
         exports.nameLabel = function(_x) {
@@ -971,7 +971,7 @@ define(function(require) {
          * Configurable extension of the x axis
          * if your max point was 50% you might want to show x axis to 60%, pass 1.2
          * @param  {number} _x ratio to max data point to add to the x axis
-         * @return { ratio | module} Current ratio or Chart module to chain calls
+         * @return {ratio | module} Current ratio or Chart module to chain calls
          * @public
          */
         exports.percentageAxisToMaxRatio = function(_x) {
@@ -986,7 +986,7 @@ define(function(require) {
         /**
          * Gets or Sets whether the color list should be reversed or not
          * @param  {boolean} _x     Should reverse the color list
-         * @return { boolean | module} Is color list being reversed
+         * @return {boolean | module} Is color list being reversed
          * @public
          */
         exports.shouldReverseColorList = function(_x) {
@@ -1002,7 +1002,7 @@ define(function(require) {
         /**
          * Changes the order of items given the custom function
          * @param  {Function} _x             A custom function that sets logic for ordering
-         * @return { (Function | Module) }   Updated module with ordering function applied
+         * @return {(Function | Module)}   Updated module with ordering function applied
          * @public
          */
         exports.orderingFunction = function(_x) {
@@ -1032,7 +1032,7 @@ define(function(require) {
         /**
          * Gets or Sets the width of the chart
          * @param  {number} _x Desired width for the graph
-         * @return { width | module} Current width or Chart module to chain calls
+         * @return {width | module} Current width or Chart module to chain calls
          * @public
          */
         exports.width = function(_x) {

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -1004,7 +1004,7 @@ define(function(require) {
         /**
          * Changes the order of items given the custom function
          * @param  {Function} _x             A custom function that sets logic for ordering
-         * @return {(Function | Module)}   Updated module with ordering function applied or Chart module to chain calls
+         * @return {(Function | Module)}   A custom ordering function or Chart module to chain calls
          * @public
          */
         exports.orderingFunction = function(_x) {

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -797,7 +797,7 @@ define(function(require) {
         /**
          * Gets or Sets the highlightBarFunction function.
          * @param  {Function} _x        Desired operation operation on a hovered bar passed through callback
-         * @return { highlightBarFunction | module} Is highlightBarFunction used or Chart module to chain calls
+         * @return {highlightBarFunction | module} Is highlightBarFunction used or Chart module to chain calls
          * @public
          */
         exports.highlightBarFunction = function(_x) {

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -806,7 +806,7 @@ define(function(require) {
          * @param  {Function} _x        Desired operation operation on a hovered bar passed through callback
          * @return {highlightBarFunction | module} Is highlightBarFunction used or Chart module to chain calls
          * @public
-         * @example barChart.highlightBarFunction(e => d3.select(e).attr('fill', expectedHighlightColor))
+         * @example barChart.highlightBarFunction(e => d3.select(e).attr('fill', blue))
          * @example barChart.highlightBarFunction(e => null) // will disable the default highlight effect
          */
         exports.highlightBarFunction = function(_x) {

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -795,10 +795,17 @@ define(function(require) {
         };
 
         /**
-         * Gets or Sets the highlightBarFunction function.
+         * Gets or Sets the highlightBarFunction function. The callback passed to
+         * this function returns a bar component from the bar chart. Use this function
+         * if you want to apply a custom behavior to the highlighted bar on hover.
+         * When hasSingleBarHighlight is true the highlighted bar will be the
+         * one that was hovered by the user. When hasSingleBarHighlight is false
+         * the highlighted bars are all the bars but the hovered one. The default
+         * highlight effect on a bar is darkening the highlighted bar(s) color.
          * @param  {Function} _x        Desired operation operation on a hovered bar passed through callback
          * @return {highlightBarFunction | module} Is highlightBarFunction used or Chart module to chain calls
          * @public
+         * @example barChart.highlightBarFunction(e => d3.select(e).attr('fill', expectedHighlightColor))
          */
         exports.highlightBarFunction = function(_x) {
             if (!highlightBarFunction.length) {

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -987,7 +987,7 @@ define(function(require) {
         /**
          * Gets or Sets whether the color list should be reversed or not
          * @param  {boolean} _x     Should reverse the color list
-         * @return {boolean | module} Is color list being reversed
+         * @return {boolean | module} Is color list being reversed or Chart module to chain calls
          * @public
          */
         exports.shouldReverseColorList = function(_x) {
@@ -1003,7 +1003,7 @@ define(function(require) {
         /**
          * Changes the order of items given the custom function
          * @param  {Function} _x             A custom function that sets logic for ordering
-         * @return {(Function | Module)}   Updated module with ordering function applied
+         * @return {(Function | Module)}   Updated module with ordering function applied or Chart module to chain calls
          * @public
          */
         exports.orderingFunction = function(_x) {

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -105,6 +105,7 @@ define(function(require) {
             animationStepRatio = 70,
             interBarDelay = (d, i) => animationStepRatio * i,
 
+            highlightBarFunction = (bar) => d3Selection.select(bar).attr('fill', ({name}) => d3Color.color(colorMap(name)).darker()),
             orderingFunction,
 
             valueLabel = 'value',
@@ -642,7 +643,7 @@ define(function(require) {
             dispatcher.call('customMouseOver', e, d, d3Selection.mouse(e), [chartWidth, chartHeight]);
 
             if (hasSingleBarHighlight) {
-                d3Selection.select(e).attr('fill', ({name}) => d3Color.color(colorMap(name)).darker());
+                highlightBarFunction(e);
                 return;
             }
 
@@ -650,7 +651,7 @@ define(function(require) {
                 if (barRect === e) {
                     return;
                 }
-                d3Selection.select(barRect).attr('fill', ({name}) => d3Color.color(colorMap(name)).darker());
+                highlightBarFunction(barRect);
             });
         }
 
@@ -792,6 +793,21 @@ define(function(require) {
 
             return this;
         };
+
+        /**
+         * Gets or Sets the highlightBarFunction function.
+         * @param  {Function} _x        Desired operation operation on a hovered bar passed through callback
+         * @return { highlightBarFunction | module} Is highlightBarFunction used or Chart module to chain calls
+         * @public
+         */
+        exports.highlightBarFunction = function(_x) {
+            if (!highlightBarFunction.length) {
+                return highlightBarFunction;
+            }
+            highlightBarFunction = _x;
+
+            return this;
+        }
 
         /**
          * Gets or Sets the isAnimated property of the chart, making it to animate when render.

--- a/test/specs/bar.spec.js
+++ b/test/specs/bar.spec.js
@@ -165,7 +165,7 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
 
             it('should change behavior of the hovered bar', () => {
                 let expectedHighlightColor = '#ffffff';
-                let customHighlightFunction = e => d3.select(e).attr('fill', expectedHighlightColor);
+                let customHighlightFunction = barSelection => barSelection.attr('fill', expectedHighlightColor);
 
                 barChart.highlightBarFunction(customHighlightFunction);
                 let bar = containerFixture.selectAll('.bar:nth-child(1)');
@@ -181,7 +181,7 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
 
             it('should change the behavior of non-hovered bars when hasSingleBarHighlight is False', () => {
                 let expectedHighlightColor = '#ffffff';
-                let customHighlightFunction = e => d3.select(e).attr('fill', expectedHighlightColor);
+                let customHighlightFunction = barSelection => barSelection.attr('fill', expectedHighlightColor);
 
                 barChart.hasSingleBarHighlight(false);
                 barChart.highlightBarFunction(customHighlightFunction);

--- a/test/specs/bar.spec.js
+++ b/test/specs/bar.spec.js
@@ -1,7 +1,7 @@
 define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
     'use strict';
 
-    const aTestDataSet = () => new dataBuilder.BarDataBuilder();    
+    const aTestDataSet = () => new dataBuilder.BarDataBuilder();
     const buildDataSet = (dataSetName) => {
         return aTestDataSet()
             [dataSetName]()
@@ -107,7 +107,7 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
             });
 
             it('accepts a custom ascending sorting function', () => {
-                let fn = (a, b) => a.value - b.value; 
+                let fn = (a, b) => a.value - b.value;
                 let actual,
                     expected = {
                         name: 'Z',
@@ -158,6 +158,44 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
                 expect(actualHasHover).toBe(expectedHasBarHighlight);
                 expect(actualColor).toBe(expectedColor);
                 expect(actualColor).toBe(hoverColor);
+            });
+        });
+
+        describe('when highlightBarFunction is called', () => {
+
+            it('should change behavior of the hovered bar', () => {
+                let expectedHighlightColor = '#ffffff';
+                let customHighlightFunction = (e) => d3.select(e).attr('fill', expectedHighlightColor);
+
+                barChart.highlightBarFunction(customHighlightFunction);
+                let bar = containerFixture.selectAll('.bar:nth-child(1)');
+
+                let beforeHighlightColor = bar.attr('fill');
+
+                bar.dispatch('mouseover');
+                let actualHighlightColor = bar.attr('fill');
+
+                expect(actualHighlightColor).toBe(expectedHighlightColor);
+                expect(beforeHighlightColor).not.toBe(expectedHighlightColor);
+            });
+
+            it('should change the behavior of non-hovered bars when hasSingleBarHighlight is False', () => {
+                let expectedHighlightColor = '#ffffff';
+                let customHighlightFunction = (e) => d3.select(e).attr('fill', expectedHighlightColor);
+
+                barChart.hasSingleBarHighlight(false);
+                barChart.highlightBarFunction(customHighlightFunction);
+                let barNotHighlighted = containerFixture.selectAll('.bar:nth-child(1)');
+                let barHighlighted = containerFixture.selectAll('.bar:nth-child(2)');
+
+                let beforeHighlightColor = barNotHighlighted.attr('fill');
+
+                barNotHighlighted.dispatch('mouseover');
+                let actualNotHighlightColor = barNotHighlighted.attr('fill');
+                let actualHighlightColor = barHighlighted.attr('fill');
+
+                expect(actualHighlightColor).toBe(expectedHighlightColor);
+                expect(actualNotHighlightColor).toBe(beforeHighlightColor);
             });
         });
 

--- a/test/specs/bar.spec.js
+++ b/test/specs/bar.spec.js
@@ -165,7 +165,7 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
 
             it('should change behavior of the hovered bar', () => {
                 let expectedHighlightColor = '#ffffff';
-                let customHighlightFunction = (e) => d3.select(e).attr('fill', expectedHighlightColor);
+                let customHighlightFunction = e => d3.select(e).attr('fill', expectedHighlightColor);
 
                 barChart.highlightBarFunction(customHighlightFunction);
                 let bar = containerFixture.selectAll('.bar:nth-child(1)');
@@ -181,7 +181,7 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
 
             it('should change the behavior of non-hovered bars when hasSingleBarHighlight is False', () => {
                 let expectedHighlightColor = '#ffffff';
-                let customHighlightFunction = (e) => d3.select(e).attr('fill', expectedHighlightColor);
+                let customHighlightFunction = e => d3.select(e).attr('fill', expectedHighlightColor);
 
                 barChart.hasSingleBarHighlight(false);
                 barChart.highlightBarFunction(customHighlightFunction);


### PR DESCRIPTION
## Description
Added a function to `Bar` chart's API  to allow the user to pass a function as a callback to `highlightBarFunction` which which passes the highlighted bar through the callback for the user to manipulate it.. That way, developer can operate on a bar. For example, change the `fill` property using select or `d3Color`.

```
barChart.highlightBarFunction(barSelection => barSelection.attr('fill', 'blue'))
```

## Motivation and Context
There was initial discussion in https://github.com/eventbrite/britecharts/issues/485 and in the merged PR: https://github.com/eventbrite/britecharts/pull/500 on allowing the user to have more customization over `Bar` chart highlighting.

## How Has This Been Tested?
* Added 2 new tests to `bar.spec.js` that check whether the highlighting is applied with custom function correctly when `hasSingleBarHighlight` is either set to `true` or `false`.
* `yarn test`.

## Screenshots (if appropriate):
Applying `lightblue` color `barSelection.attr('fill',  'lightblue')`:
* `hasSingleBarHighlight` is `true` (Default)
![screen shot 2018-02-03 at 11 33 56 pm](https://user-images.githubusercontent.com/31934144/35775825-39ae5238-0945-11e8-9e61-7ba735e442b4.png)

* `hasSingleBarHighlight` is `false`:
![screen shot 2018-02-04 at 12 57 20 am](https://user-images.githubusercontent.com/31934144/35775874-68e29bf8-0946-11e8-81ad-317f4eff6dba.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
