### PR TITLE
Feature - allow ability to configure stacked area curve

### DIFF
--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -812,7 +812,7 @@ define(function(require) {
          * barChart.highlightBarFunction(null) // will disable the default highlight effect
          */
         exports.highlightBarFunction = function(_x) {
-            if (!highlightBarFunction.length) {
+            if (!arguments.length) {
                 return highlightBarFunction;
             }
             highlightBarFunction = _x;

--- a/src/charts/helpers/constants.js
+++ b/src/charts/helpers/constants.js
@@ -1,5 +1,7 @@
 define(function() {
 
+    const d3Shape = require('d3-shape');
+
     const axisTimeCombinations = {
         MINUTE_HOUR: 'minute-hour',
         HOUR_DAY: 'hour-daymonth',
@@ -14,6 +16,19 @@ define(function() {
         ONE_DAY: 86400001
     };
 
+    const curveMap = {
+        linear: d3Shape.curveLinear,
+        basis: d3Shape.curveBasis,
+        cardinal: d3Shape.curveCardinal,
+        catmullRom: d3Shape.curveCatmullRom,
+        monotoneX: d3Shape.curveMonotoneX,
+        monotoneY: d3Shape.curveMonotoneY,
+        natural: d3Shape.curveNatural,
+        step: d3Shape.curveStep,
+        stepAfter: d3Shape.curveStepAfter,
+        stepBefore: d3Shape.curveStepBefore
+    };
+
     const emptyDonutData = [{
         'quantity': 1,
         'percentage': 100
@@ -21,6 +36,7 @@ define(function() {
 
     return {
         axisTimeCombinations,
+        curveMap,
         emptyDonutData,
         timeBenchmarks,
         lineGradientId: 'lineGradientId'

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -21,7 +21,7 @@ define(function(require){
         getXAxisSettings,
         getLocaleDateFormatter
     } = require('./helpers/timeAxis');
-    const { axisTimeCombinations } = require('./helpers/constants');
+    const { axisTimeCombinations, curveMap } = require('./helpers/constants');
     const {
         createFilterContainer,
         createGlowWithMatrix,
@@ -172,18 +172,6 @@ define(function(require){
             maskingRectangle,
 
             lineCurve = 'linear',
-            curveMap = {
-                linear: d3Shape.curveLinear,
-                basis: d3Shape.curveBasis,
-                cardinal: d3Shape.curveCardinal,
-                catmullRom: d3Shape.curveCatmullRom,
-                monotoneX: d3Shape.curveMonotoneX,
-                monotoneY: d3Shape.curveMonotoneY,
-                natural: d3Shape.curveNatural,
-                step: d3Shape.curveStep,
-                stepAfter: d3Shape.curveStepAfter,
-                stepBefore: d3Shape.curveStepBefore
-            },
 
             dataByTopic,
             dataByDate,

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -19,7 +19,7 @@ define(function(require){
         getXAxisSettings,
         getLocaleDateFormatter
     } = require('./helpers/timeAxis');
-    const {axisTimeCombinations} = require('./helpers/constants');
+    const {axisTimeCombinations, curveMap} = require('./helpers/constants');
     const {
         formatIntegerValue,
         formatDecimalValue
@@ -127,7 +127,7 @@ define(function(require){
             locale,
 
             baseLine,
-            areaCurve = d3Shape.curveStep,
+            areaCurve = 'monotoneX',
 
             layers,
             series,
@@ -709,7 +709,7 @@ define(function(require){
             }
 
             area = d3Shape.area()
-                .curve(areaCurve)
+                .curve(curveMap[areaCurve])
                 .x( ({data}) => xScale(data.date) )
                 .y0( (d) => yScale(d[0]) )
                 .y1( (d) => yScale(d[1]) );

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -127,6 +127,7 @@ define(function(require){
             locale,
 
             baseLine,
+            areaCurve = d3Shape.curveStep,
 
             layers,
             series,
@@ -708,7 +709,7 @@ define(function(require){
             }
 
             area = d3Shape.area()
-                .curve(d3Shape.curveMonotoneX)
+                .curve(areaCurve)
                 .x( ({data}) => xScale(data.date) )
                 .y0( (d) => yScale(d[0]) )
                 .y1( (d) => yScale(d[1]) );
@@ -1027,6 +1028,20 @@ define(function(require){
 
 
         // API
+
+         /**
+         * @param {String} _x Desired setting for the area curve
+         * @return { lineCurve | module } Current area curve setting or Chart module to chain calls
+         * @public
+         */
+        exports.areaCurve = function(_x) {
+            if (!arguments.length) {
+                return areaCurve;
+            }
+            areaCurve = _x;
+
+            return this;
+        }
 
         /**
          * Gets or Sets the opacity of the stacked areas in the chart (all of them will have the same opacity)

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -710,14 +710,14 @@ define(function(require){
 
             area = d3Shape.area()
                 .curve(curveMap[areaCurve])
-                .x( ({data}) => xScale(data.date) )
-                .y0( (d) => yScale(d[0]) )
-                .y1( (d) => yScale(d[1]) );
+                .x(({data})=> xScale(data.date))
+                .y0((d) => yScale(d[0]))
+                .y1((d) => yScale(d[1]));
 
             areaOutline = d3Shape.line()
                 .curve(area.curve())
-                .x( ({data}) => xScale(data.date) )
-                .y( (d) => yScale(d[1]) );
+                .x(({data}) => xScale(data.date))
+                .y((d) => yScale(d[1]));
 
             if (isAnimated) {
                 series = svg.select('.chart-group').selectAll('.layer')
@@ -743,7 +743,7 @@ define(function(require){
                 svg.select('.chart-group').selectAll('.layer')
                     .data(layers)
                     .transition()
-                    .delay( (_, i) => areaAnimationDelays[i])
+                    .delay((_, i) => areaAnimationDelays[i])
                     .duration(areaAnimationDuration)
                     .ease(ease)
                     .attr('d', area)
@@ -1033,6 +1033,7 @@ define(function(require){
          * @param {String} _x Desired setting for the area curve
          * @return { lineCurve | module } Current area curve setting or Chart module to chain calls
          * @public
+         * @example stackedArea.areaCurve('step')
          */
         exports.areaCurve = function(_x) {
             if (!arguments.length) {

--- a/test/specs/stacked-area.spec.js
+++ b/test/specs/stacked-area.spec.js
@@ -13,7 +13,7 @@ define([
     ) {
     'use strict';
 
-    const aTestDataSet = () => new dataBuilder.StackedAreaDataBuilder();    
+    const aTestDataSet = () => new dataBuilder.StackedAreaDataBuilder();
     const buildDataSet = (dataSetName) => {
         return aTestDataSet()
             [dataSetName]()
@@ -187,7 +187,7 @@ define([
         });
 
         describe('when reloading with a three sources dataset', () => {
-            
+
             it('should render in the same svg', function() {
                 let actual;
                 let expected = 1;
@@ -238,7 +238,7 @@ define([
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);
             });
-            
+
             it('should provide an aspect ratio getter and setter', () => {
                 let previous = stackedAreaChart.aspectRatio(),
                     expected = 600,
@@ -466,6 +466,18 @@ define([
 
                 stackedAreaChart.yTicks(expected);
                 actual = stackedAreaChart.yTicks();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
+            it('should provide areaCurve getter and setter', () => {
+                let previous = stackedAreaChart.areaCurve(),
+                    expected = 'step',
+                    actual;
+
+                stackedAreaChart.areaCurve(expected);
+                actual = stackedAreaChart.areaCurve();
 
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);


### PR DESCRIPTION
## Description
* Added a new public method to the `StackedArea` chart that allows the user to configure the curve settings dynamically.
* Moved the `curveMap` to constants to make it shareable between different chart components. Currently it is used for both `Line` and `StackedArea` charts.

## Motivation and Context
It's cool to be able to customize the area's curve. Also, it was requested a little while ago in https://github.com/eventbrite/britecharts/issues/455 issue.

## How Has This Been Tested?
* Added a new setter/getter test in `stacked-area.spec.js`
* `yarn test`

## Screenshots (if appropriate):
- `stackArea.areaCurve('step'):`
<img width="1210" alt="screen shot 2018-02-05 at 9 49 45 pm" src="https://user-images.githubusercontent.com/31934144/35844324-bbd75ed0-0ac1-11e8-99ee-1bbd0b69754f.png">

- `stackArea.areaCurve('basis'):`

<img width="1211" alt="screen shot 2018-02-05 at 10 10 51 pm" src="https://user-images.githubusercontent.com/31934144/35844354-dd0be7d8-0ac1-11e8-8078-fa9af87f77e2.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
