### PR TITLE
Feature - ability to set y-axis label and its offset in Grouped Bar chart

### DIFF
--- a/demos/demo-grouped-bar.js
+++ b/demos/demo-grouped-bar.js
@@ -92,8 +92,6 @@ function createHorizontalgroupedBarChart(optionalColorSchema) {
                 right: 30,
                 bottom: 20
             })
-            .yAxisLabel('Tickets Sold')
-            .yAxisLabelOffset(-60)
             .nameLabel('date')
             .valueLabel('views')
             .groupLabel('stack')

--- a/demos/demo-grouped-bar.js
+++ b/demos/demo-grouped-bar.js
@@ -92,6 +92,8 @@ function createHorizontalgroupedBarChart(optionalColorSchema) {
                 right: 30,
                 bottom: 20
             })
+            .yAxisLabel('Tickets Sold')
+            .yAxisLabelOffset(-60)
             .nameLabel('date')
             .valueLabel('views')
             .groupLabel('stack')

--- a/src/charts/grouped-bar.js
+++ b/src/charts/grouped-bar.js
@@ -119,6 +119,10 @@ define(function (require) {
                 bottom: 0,
                 right: 0
             },
+            yAxisLabel,
+            yAxisLabelEl,
+            yAxisLabelOffset = -60,
+
             maxBarNumber = 8,
             barOpacity = 0.24,
 
@@ -238,6 +242,9 @@ define(function (require) {
                 .append('g').classed('month-axis', true);
             container
                 .append('g').classed('y-axis-group axis', true);
+            container
+                .append('g')
+                    .classed('y-axis-label', true)
             container
                 .append('g').classed('grid-lines-group', true);
             container
@@ -379,6 +386,21 @@ define(function (require) {
                     .attr('transform', `translate( ${-xAxisPadding.left}, 0)`)
                     .call(yAxis)
                     .call(adjustYTickLabels);
+            }
+
+            if (yAxisLabel) {
+                if (yAxisLabelEl) {
+                    svg.selectAll('y.axis-label-text').remove();
+                }
+
+                yAxisLabelEl = svg.select('.y-axis-label')
+                    .append('text')
+                        .classed('y-axis-label-text', true)
+                        .attr('x', -chartHeight / 2)
+                        .attr('y', yAxisLabelOffset)
+                        .attr('text-anchor', 'middle')
+                        .attr('transform', 'rotate(270 0 0)')
+                        .text(yAxisLabel)
             }
         }
 
@@ -1045,6 +1067,30 @@ define(function (require) {
 
             return this;
         };
+
+        /**
+         * Gets or Sets the y-axis label of the chart
+         * @param  {String} _x Desired label string
+         * @return {Object | module} Current yAxisLabel or Chart module to chain calls
+         * @public
+         */
+        exports.yAxisLabel = function (_x) {
+            if (!arguments.length) {
+                return yAxisLabel;
+            }
+            yAxisLabel = _x;
+
+            return this;
+        };
+
+        exports.yAxisLabelOffset = function (_x) {
+            if (!arguments.length) {
+                return yAxisLabelOffset;
+            }
+            yAxisLabelOffset = _x;
+
+            return this;
+        }
 
         /**
          * Gets or Sets the x and y offset of ticks of the y axis on the chart

--- a/src/charts/grouped-bar.js
+++ b/src/charts/grouped-bar.js
@@ -1071,8 +1071,9 @@ define(function (require) {
         /**
          * Gets or Sets the y-axis label of the chart
          * @param  {String} _x Desired label string
-         * @return {Object | module} Current yAxisLabel or Chart module to chain calls
+         * @return {String | module} Current yAxisLabel or Chart module to chain calls
          * @public
+         * @example groupedBar.yAxisLabel('Ticket Sales')
          */
         exports.yAxisLabel = function (_x) {
             if (!arguments.length) {
@@ -1083,6 +1084,15 @@ define(function (require) {
             return this;
         };
 
+        /**
+         * Gets or Sets the offset of the yAxisLabel of the chart.
+         * The method accepts both positive and negative values.
+         * The default value is -60
+         * @param  {Integer} _x Desired offset for the label
+         * @return {Integer | module} Current yAxisLabelOffset or Chart module to chain calls
+         * @public
+         * @example groupedBar.yAxisLabelOffset(-55)
+         */
         exports.yAxisLabelOffset = function (_x) {
             if (!arguments.length) {
                 return yAxisLabelOffset;

--- a/src/charts/grouped-bar.js
+++ b/src/charts/grouped-bar.js
@@ -390,7 +390,7 @@ define(function (require) {
 
             if (yAxisLabel) {
                 if (yAxisLabelEl) {
-                    svg.selectAll('y.axis-label-text').remove();
+                    svg.selectAll('.y-axis-label-text').remove();
                 }
 
                 yAxisLabelEl = svg.select('.y-axis-label')

--- a/test/specs/grouped-bar.spec.js
+++ b/test/specs/grouped-bar.spec.js
@@ -346,7 +346,7 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
             });
 
             it('should provide yAxisLabelOffset getter and setter', () => {
-                let defaultYAxisLabelOffset = -40,
+                let defaultYAxisLabelOffset =  groupedBarChart.yAxisLabelOffset(),
                     testYAxisLabelOffset = -30,
                     newYAxisLabelOffset;
 

--- a/test/specs/grouped-bar.spec.js
+++ b/test/specs/grouped-bar.spec.js
@@ -295,7 +295,7 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
 
             it('should provide valueLabelFormat getter and setter', () => {
                 let previous = groupedBarChart.valueLabelFormat(),
-                    expected = 's',
+                    expected = 'something',
                     actual;
 
                 groupedBarChart.valueLabelFormat(expected);
@@ -331,6 +331,30 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
 
                 expect(previous).not.toBe(actual);
                 expect(actual).toBe(expected);
+            });
+
+            it('should provide yAxisLabel getter and setter', () => {
+                let defaultYAxisLabel = 'Hello',
+                    testYAxisLabel = 'World',
+                    newYAxisLabel;
+
+                groupedBarChart.yAxisLabel(testYAxisLabel);
+                newYAxisLabel = groupedBarChart.yAxisLabel();
+
+                expect(defaultYAxisLabel).not.toBe(newYAxisLabel);
+                expect(newYAxisLabel).toBe(testYAxisLabel);
+            });
+
+            it('should provide yAxisLabelOffset getter and setter', () => {
+                let defaultYAxisLabelOffset = -40,
+                    testYAxisLabelOffset = -30,
+                    newYAxisLabelOffset;
+
+                groupedBarChart.yAxisLabelOffset(testYAxisLabelOffset);
+                newYAxisLabelOffset = groupedBarChart.yAxisLabelOffset();
+
+                expect(defaultYAxisLabelOffset).not.toBe(newYAxisLabelOffset);
+                expect(newYAxisLabelOffset).toBe(testYAxisLabelOffset);
             });
         });
 

--- a/test/specs/grouped-bar.spec.js
+++ b/test/specs/grouped-bar.spec.js
@@ -295,7 +295,7 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
 
             it('should provide valueLabelFormat getter and setter', () => {
                 let previous = groupedBarChart.valueLabelFormat(),
-                    expected = 'something',
+                    expected = 's',
                     actual;
 
                 groupedBarChart.valueLabelFormat(expected);

--- a/test/specs/step.spec.js
+++ b/test/specs/step.spec.js
@@ -1,17 +1,17 @@
 define([
-    'jquery', 
-    'd3', 
-    'step', 
+    'jquery',
+    'd3',
+    'step',
     'stepChartDataBuilder'
 ], function(
-    $, 
-    d3, 
-    chart, 
+    $,
+    d3,
+    chart,
     dataBuilder
 ) {
     'use strict';
 
-    const aTestDataSet = () => new dataBuilder.StepDataBuilder();    
+    const aTestDataSet = () => new dataBuilder.StepDataBuilder();
     const buildDataSet = (dataSetName) => {
         return aTestDataSet()
             [dataSetName]()
@@ -72,7 +72,7 @@ define([
         });
 
         describe('when reloading with a different dataset', () => {
-            
+
             it('should render in the same svg', function() {
                 let actual;
                 let expected = 1;


### PR DESCRIPTION
## Description
There are 2 new methods added to `GroupedBar` chart: `yAxisLabelOffset` and `yAxisLabel` similar to those that exist in `Line` and `Step` charts.

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/514

## How Has This Been Tested?
* Added 2 new unit tests for `setter` and `getter` of the 2 new methods.
* `yarn test`

## Screenshots (if appropriate):
<img width="1251" alt="screen shot 2018-02-16 at 12 16 39 am" src="https://user-images.githubusercontent.com/31934144/36300303-9fe36c5e-12b5-11e8-92e3-13f23613dadd.png">

<img width="1270" alt="screen shot 2018-02-16 at 1 09 16 am" src="https://user-images.githubusercontent.com/31934144/36300396-0fc00adc-12b6-11e8-9595-c7dd5b4f58af.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
