### PR TITLE
Bug - Fixes the label overlap on data change of the Bar chart

### DIFF
--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -110,6 +110,7 @@ define(function(require) {
 
             valueLabel = 'value',
             nameLabel = 'name',
+            labelEl,
 
             baseLine,
             maskGridLines,
@@ -491,7 +492,11 @@ define(function(require) {
             let labelYPosition = isHorizontal ? _labelsHorizontalY : _labelsVerticalY;
             let text = _labelsFormatValue
 
-            let labels = svg.select('.metadata-group')
+            if (labelEl) {
+                svg.selectAll('.percentage-label-group').remove();
+            }
+
+            labelEl = svg.select('.metadata-group')
               .append('g')
                 .classed('percentage-label-group', true)
                 .selectAll('text')
@@ -499,7 +504,7 @@ define(function(require) {
                 .enter()
               .append('text');
 
-            labels
+            labelEl
                 .classed('percentage-label', true)
                 .attr('x', labelXPosition)
                 .attr('y', labelYPosition)


### PR DESCRIPTION
Fixes the label overlap on data change for bar chart.

## Description
Labels were overlapping because the existing ones were not cleaned up on re-render. I added a module variable `labelEl` that is used as a label element. If it has value, the labels are deleted, so that makes the cleanup work.

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/510

## How Has This Been Tested?
* Visual test.
* `yarn test`

## Screenshots (if appropriate):
* Before fix:
![barchart_not_fixed_demo](https://user-images.githubusercontent.com/31934144/36338460-5e600daa-1364-11e8-8226-81acd7004e61.gif)
* After fix:
![barchart_fixed_demo](https://user-images.githubusercontent.com/31934144/36338462-69c49de6-1364-11e8-9a1c-348023745fd5.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
