### PR TITLE
Feaeture - touchmove event dispatch handlers for Line and StackedArea

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -213,7 +213,8 @@ define(function(require){
                 'customMouseOver',
                 'customMouseOut',
                 'customMouseMove',
-                'customDataEntryClick'
+                'customDataEntryClick',
+                'customTouchMove'
             );
 
         /**
@@ -246,6 +247,8 @@ define(function(require){
                     drawVerticalMarker();
                     addMouseEvents();
                 }
+
+                addTouchEvents();
             });
         }
 
@@ -281,6 +284,17 @@ define(function(require){
                 })
                 .on('mousemove',  function(d) {
                     handleMouseMove(this, d);
+                });
+        }
+
+        /**
+         * Adds events to the container group for the mobile devices
+         * Adding: touch
+         */
+        function addTouchEvents() {
+            svg
+                .on('touchmove', function(d) {
+                    handleTouchMove(this, d);
                 });
         }
 
@@ -825,6 +839,15 @@ define(function(require){
         }
 
         /**
+         * Mouseclick handler over one of the highlight points
+         * It will only pass the information with the event
+         * @private
+         */
+        function handleTouchMove(e, d) {
+            dispatcher.call('customTouchMove', e, d, d3Selection.touch(e));
+        }
+
+        /**
          * Creates coloured circles marking where the exact data y value is for a given data point
          * @param  {Object} dataPoint Data point to extract info from
          * @private
@@ -1321,7 +1344,8 @@ define(function(require){
         /**
          * Exposes an 'on' method that acts as a bridge with the event dispatcher
          * We are going to expose this events:
-         * customMouseHover, customMouseMove, customMouseOut and customDataEntryClick
+         * customMouseHover, customMouseMove, customMouseOut, 
+         * customDataEntryClick, and customTouchMove
          *
          * @return {module} Bar Chart
          * @public

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -288,8 +288,9 @@ define(function(require){
         }
 
         /**
-         * Adds events to the container group for the mobile devices
-         * Adding: touch
+         * Adds events to the container group for the mobile environment
+         * Adding: touchmove
+         * @private
          */
         function addTouchEvents() {
             svg
@@ -839,7 +840,7 @@ define(function(require){
         }
 
         /**
-         * Mouseclick handler over one of the highlight points
+         * Touchmove highlighted points
          * It will only pass the information with the event
          * @private
          */

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -193,7 +193,13 @@ define(function(require){
             getDate = ({date}) => date,
 
             // events
-            dispatcher = d3Dispatch.dispatch('customMouseOver', 'customMouseOut', 'customMouseMove', 'customDataEntryClick');
+            dispatcher = d3Dispatch.dispatch(
+                'customMouseOver',
+                'customMouseOut',
+                'customMouseMove',
+                'customDataEntryClick',
+                'customTouchMove'
+            );
 
        /**
          * This function creates the graph using the selection and data provided
@@ -214,6 +220,8 @@ define(function(require){
                 buildAxis();
                 drawAxis();
                 drawStackedAreas();
+
+                addTouchEvents();
 
                 if (shouldShowTooltip()) {
                     drawHoverOverlay();
@@ -256,6 +264,18 @@ define(function(require){
                 })
                 .on('mousemove',  function(d) {
                     handleMouseMove(this, d);
+                });
+        }
+
+        /**
+         * Adds events to the container group for the mobile environment
+         * Adding: touchmove
+         * @private
+         */
+        function addTouchEvents() {
+            svg
+                .on('touchmove', function(d) {
+                    handleTouchMove(this, d);
                 });
         }
 
@@ -967,6 +987,15 @@ define(function(require){
         }
 
         /**
+         * Touchmove highlighted points
+         * It will only pass the information with the event
+         * @private
+         */
+        function handleTouchMove(e, d) {
+            dispatcher.call('customTouchMove', e, d, d3Selection.touch(e));
+        }
+
+        /**
          * Mouseclick handler over one of the highlight points
          * It will only pass the information with the event
          * @private
@@ -1298,9 +1327,9 @@ define(function(require){
         /**
          * Exposes an 'on' method that acts as a bridge with the event dispatcher
          * We are going to expose this events:
-         * customMouseOver, customMouseMove, customMouseOut and customDataEntryClick
-         *
-         * @return {module} Bar Chart
+         * customMouseOver, customMouseMove, customMouseOut, 
+         * customDataEntryClick and customTouchMove
+         * @return {module} Stacked Area
          * @public
          */
         exports.on = function() {

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -126,17 +126,6 @@ define([
                 });
 
                 // Event Setting
-                it('should trigger an event on touchmove', () => {
-                    let callback = jasmine.createSpy('touchMoveCallback'),
-                        container = containerFixture.selectAll('svg');
-
-                    lineChart.on('customTouchMove', callback);
-                    container.dispatch('touchmove');
-
-                    expect(callback.calls.count()).toBe(1);
-                    expect(callback.calls.allArgs()[0].length).toBe(2);
-                });
-
                 it('should trigger an event on hover', () => {
                     let callback = jasmine.createSpy('hoverCallback'),
                         container = containerFixture.selectAll('svg');
@@ -154,6 +143,17 @@ define([
 
                     lineChart.on('customMouseOut', callback);
                     container.dispatch('mouseout');
+                    expect(callback.calls.count()).toBe(1);
+                    expect(callback.calls.allArgs()[0].length).toBe(2);
+                });
+
+                it('should trigger an event on touchmove', () => {
+                    let callback = jasmine.createSpy('touchMoveCallback'),
+                        container = containerFixture.selectAll('svg');
+
+                    lineChart.on('customTouchMove', callback);
+                    container.dispatch('touchmove');
+
                     expect(callback.calls.count()).toBe(1);
                     expect(callback.calls.allArgs()[0].length).toBe(2);
                 });

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -126,6 +126,17 @@ define([
                 });
 
                 // Event Setting
+                it('should trigger an event on touchmove', () => {
+                    let callback = jasmine.createSpy('touchMoveCallback'),
+                        container = containerFixture.selectAll('svg');
+
+                    lineChart.on('customTouchMove', callback);
+                    container.dispatch('touchmove');
+
+                    expect(callback.calls.count()).toBe(1);
+                    expect(callback.calls.allArgs()[0].length).toBe(2);
+                });
+
                 it('should trigger an event on hover', () => {
                     let callback = jasmine.createSpy('hoverCallback'),
                         container = containerFixture.selectAll('svg');

--- a/test/specs/stacked-area.spec.js
+++ b/test/specs/stacked-area.spec.js
@@ -167,6 +167,18 @@ define([
             expect(callback.calls.allArgs()[0].length).toBe(2);
         });
 
+        it('should trigger an event on touchmove', () => {
+            let callback = jasmine.createSpy('touchMoveCallback'),
+                container = containerFixture.selectAll('svg');
+
+            stackedAreaChart.on('customTouchMove', callback);
+            container.dispatch('touchmove');
+
+            expect(callback.calls.count()).toBe(1);
+            expect(callback.calls.allArgs()[0].length).toBe(2);
+        });
+
+
         it('should be able to render even when data is length 0', () => {
             expect(() => containerFixture.datum([]).call(stackedAreaChart)).not.toThrow();
         });


### PR DESCRIPTION
## Description
Added `touchmove` custom event handlers for both `Line` and `StackedArea` charts. It can be called and handled without including tooltip.

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/456

## How Has This Been Tested?
Added 1 test each for StackedArea and Line charts that check the `customTouchMove` event handler is dispatched when `touchmove` event is called.

## Screenshots (if appropriate):
`touchmove` for Stacked Area:
![barchart_touch_move_stacked_area](https://user-images.githubusercontent.com/31934144/36580335-abce603e-181c-11e8-82c1-69f10d9ed680.gif)

`touchmove` for Line:
![barchart_touch_move](https://user-images.githubusercontent.com/31934144/36580337-aebef736-181c-11e8-886f-fb012e75bc68.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
