### PR TITLE
Feature - yAxisLabelPadding setter/getter for Line chart

### DIFF
--- a/demos/demo-line.js
+++ b/demos/demo-line.js
@@ -68,6 +68,7 @@ function createLineChart(optionalColorSchema, optionalData) {
             .isAnimated(true)
             .aspectRatio(0.5)
             .grid('horizontal')
+            .yAxisLabel('Tickets')
             .tooltipThreshold(600)
             .width(containerWidth)
             .margin(lineMargin)
@@ -77,7 +78,7 @@ function createLineChart(optionalColorSchema, optionalData) {
             .on('customMouseOut', chartTooltip.hide)
             .on('customDataEntryClick', function(d, mousePosition) {
                 // console.log('Data entry marker clicked', d, mousePosition);
-            })
+            });
 
 
         if (optionalColorSchema) {

--- a/demos/demo-line.js
+++ b/demos/demo-line.js
@@ -68,7 +68,6 @@ function createLineChart(optionalColorSchema, optionalData) {
             .isAnimated(true)
             .aspectRatio(0.5)
             .grid('horizontal')
-            .yAxisLabel('Tickets')
             .tooltipThreshold(600)
             .width(containerWidth)
             .margin(lineMargin)
@@ -78,7 +77,7 @@ function createLineChart(optionalColorSchema, optionalData) {
             .on('customMouseOut', chartTooltip.hide)
             .on('customDataEntryClick', function(d, mousePosition) {
                 // console.log('Data entry marker clicked', d, mousePosition);
-            });
+            })
 
 
         if (optionalColorSchema) {

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -1254,7 +1254,7 @@ define(function(require){
         /**
          * Gets or Sets the topicLabel of the chart
          * @param  {Number} _x Desired topicLabel for the graph
-         * @return { topicLabel | module} Current topicLabel or Chart module to chain calls
+         * @return {topicLabel | module} Current topicLabel or Chart module to chain calls
          * @public
          */
         exports.topicLabel = function(_x) {
@@ -1269,7 +1269,7 @@ define(function(require){
         /**
          * Gets or Sets the valueLabel of the chart
          * @param  {Number} _x Desired valueLabel for the graph
-         * @return { valueLabel | module} Current valueLabel or Chart module to chain calls
+         * @return {valueLabel | module} Current valueLabel or Chart module to chain calls
          * @public
          */
         exports.valueLabel = function(_x) {
@@ -1280,6 +1280,22 @@ define(function(require){
 
             return this;
         };
+
+        /**
+         * Gets or Sets the yAxisLabelPadding of the chart.
+         * The default value is -36
+         * @param  {Number} _x Desired yAxisLabelPadding for the graph
+         * @return {yAxisLabelPadding | module} Current yAxisLabelPadding or Chart module to chain calls
+         * @public
+         */
+        exports.yAxisLabelPadding = function(_x) {
+            if (!arguments.length) {
+                return yAxisLabelPadding;
+            }
+            yAxisLabelPadding = _x;
+
+            return this;
+        }
 
         /**
          * Gets or Sets the number of ticks of the y axis on the chart

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -556,6 +556,18 @@ define([
                     expect(previous).not.toBe(expected);
                     expect(actual).toBe(expected);
                 });
+
+                it('should provide yAxisLabelPadding getter and setter', () => {
+                    let previous = lineChart.yAxisLabelPadding(),
+                        expected = 100,
+                        actual;
+
+                    lineChart.yAxisLabelPadding(expected);
+                    actual = lineChart.yAxisLabelPadding();
+
+                    expect(previous).not.toBe(expected);
+                    expect(actual).toBe(expected);
+                });
             });
 
             describe('Aspect Ratio', () => {


### PR DESCRIPTION
## Description
Added `yAxisLabelPadding` which was `-36` by default but the label was not seen if the y-axis values are bigger (or closer) with respect to `yAxisLabel`

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/524

## How Has This Been Tested?
Added a new setter/getter test for the method

## Screenshots (if appropriate):
Setting the padding for the y-axis label makes it visible:
<img width="810" alt="screen shot 2018-02-23 at 4 20 04 pm" src="https://user-images.githubusercontent.com/31934144/36623228-a43f4d6a-18b7-11e8-8b29-a9121e35a729.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
