### PR TITLE
Fix - Added legend demo reference to demos

### DIFF
--- a/webpack.constants.js
+++ b/webpack.constants.js
@@ -28,7 +28,8 @@ exports.DEMOS = {
     'demo-sparkline': './demos/demo-sparkline.js',
     'demo-step': './demos/demo-step.js',
     'demo-brush': './demos/demo-brush.js',
-    'demo-kitchen-sink': './demos/demo-kitchen-sink.js'
+    'demo-kitchen-sink': './demos/demo-kitchen-sink.js',
+    'demo-legend': './demos/demo-legend.js'
 };
 
 exports.PATHS = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The legend demos didn't show up. We forgot to include the legend demo reference in `DEMOS` object.

## Motivation and Context
The legend demos didn't show up.

## How Has This Been Tested?
`yarn test` and `yarn demos`

## Screenshots (if appropriate):
Demo shows up as before.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
