### PR TITLE
Fix - Removing logic for figuring out yTicks on small values

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -335,8 +335,6 @@ define(function(require){
          * @private
          */
         function buildAxis() {
-            let dataTimeSpan = yScale.domain()[1] - yScale.domain()[0];
-            let yTickNumber = dataTimeSpan < yTicks - 1 ? dataTimeSpan : yTicks;
             let minor, major;
 
             if (xAxisFormat === 'custom' && typeof xAxisCustomFormat === 'string') {
@@ -361,12 +359,12 @@ define(function(require){
                 .tickFormat(minor.format);
 
             yAxis = d3Axis.axisLeft(yScale)
-                .ticks(yTickNumber)
+                .ticks(yTicks)
                 .tickSize([0])
                 .tickPadding(tickPadding)
                 .tickFormat(getFormattedValue);
 
-            drawGridLines(minor.tick, yTickNumber);
+            drawGridLines(minor.tick, yTicks);
         }
 
         /**
@@ -1361,7 +1359,7 @@ define(function(require){
         /**
          * Exposes an 'on' method that acts as a bridge with the event dispatcher
          * We are going to expose this events:
-         * customMouseHover, customMouseMove, customMouseOut, 
+         * customMouseHover, customMouseMove, customMouseOut,
          * customDataEntryClick, and customTouchMove
          *
          * @return {module} Bar Chart

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -301,8 +301,6 @@ define(function(require){
          * @private
          */
         function buildAxis() {
-            let dataSpan = yScale.domain()[1] - yScale.domain()[0];
-            let yTickNumber = dataSpan < yTicks - 1 ? dataSpan : yTicks;
             let minor, major;
 
             if (xAxisFormat === 'custom' && typeof xAxisCustomFormat === 'string') {
@@ -328,12 +326,12 @@ define(function(require){
 
 
             yAxis = d3Axis.axisRight(yScale)
-                .ticks(yTickNumber)
+                .ticks(yTicks)
                 .tickSize([0])
                 .tickPadding(tickPadding)
                 .tickFormat(getFormattedValue);
 
-            drawGridLines(minor.tick, yTickNumber);
+            drawGridLines(minor.tick, yTicks);
         }
 
         /**
@@ -1327,7 +1325,7 @@ define(function(require){
         /**
          * Exposes an 'on' method that acts as a bridge with the event dispatcher
          * We are going to expose this events:
-         * customMouseOver, customMouseMove, customMouseOut, 
+         * customMouseOver, customMouseMove, customMouseOut,
          * customDataEntryClick and customTouchMove
          * @return {module} Stacked Area
          * @public


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In the line and stacked area charts we were performing some logic to optimize the number of ticks on small value ranges (overriding the user-set yTick value).
This wasn't working properly as reported in https://github.com/eventbrite/britecharts/issues/526
I played a bit with different values and approaches, without founding any good solution, so in this PR I am getting rid of that logic altogether. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/eventbrite/britecharts/issues/526

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

