### PR TITLE
Feature - ability to add title to Sparkline chart with custom font settings

### DIFF
--- a/demos/demo-sparkline.js
+++ b/demos/demo-sparkline.js
@@ -31,8 +31,7 @@ function createSparklineChart() {
         .isAnimated(true)
         .duration(1000)
         .height(containerWidth / 4)
-        .width(containerWidth)
-        .titleText('Growth')
+        .width(containerWidth);
 
     container.datum(dataset.data).call(sparkline);
 }

--- a/demos/demo-sparkline.js
+++ b/demos/demo-sparkline.js
@@ -32,14 +32,7 @@ function createSparklineChart() {
         .duration(1000)
         .height(containerWidth / 4)
         .width(containerWidth)
-        .titleText('Budget Growth')
-        .titleTextStyle({
-            'font-size': '22px',
-            'fill': 'red',
-            'font-family': 'Roboto',
-            'font-style': 'italic',
-            'font-weight': 400
-        });
+        .titleText('Budget Growth');
 
     container.datum(dataset.data).call(sparkline);
 }

--- a/demos/demo-sparkline.js
+++ b/demos/demo-sparkline.js
@@ -31,7 +31,8 @@ function createSparklineChart() {
         .isAnimated(true)
         .duration(1000)
         .height(containerWidth / 4)
-        .width(containerWidth);
+        .width(containerWidth)
+        .titleText('Growth')
 
     container.datum(dataset.data).call(sparkline);
 }

--- a/demos/demo-sparkline.js
+++ b/demos/demo-sparkline.js
@@ -31,8 +31,7 @@ function createSparklineChart() {
         .isAnimated(true)
         .duration(1000)
         .height(containerWidth / 4)
-        .width(containerWidth)
-        .titleText('Budget Growth');
+        .width(containerWidth);
 
     container.datum(dataset.data).call(sparkline);
 }

--- a/demos/demo-sparkline.js
+++ b/demos/demo-sparkline.js
@@ -31,7 +31,8 @@ function createSparklineChart() {
         .isAnimated(true)
         .duration(1000)
         .height(containerWidth / 4)
-        .width(containerWidth);
+        .width(containerWidth)
+        .titleText('Budget Growth');
 
     container.datum(dataset.data).call(sparkline);
 }

--- a/demos/demo-sparkline.js
+++ b/demos/demo-sparkline.js
@@ -32,7 +32,14 @@ function createSparklineChart() {
         .duration(1000)
         .height(containerWidth / 4)
         .width(containerWidth)
-        .titleText('Budget Growth');
+        .titleText('Budget Growth')
+        .titleTextStyle({
+            'font-size': '22px',
+            'fill': 'red',
+            'font-family': 'Roboto',
+            'font-style': 'italic',
+            'font-weight': 400
+        });
 
     container.datum(dataset.data).call(sparkline);
 }

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -90,6 +90,7 @@ define(function(require){
             line,
             area,
             circle,
+            title,
 
             markerSize = 1.5,
 
@@ -120,6 +121,10 @@ define(function(require){
                 drawLine();
                 drawArea();
                 drawEndMarker();
+
+                if (true) {
+                    drawSparklineTitle();
+                }
             });
         }
 
@@ -135,6 +140,8 @@ define(function(require){
                 .classed('container-group', true)
                 .attr('transform', `translate(${margin.left},${margin.top})`);
 
+            container
+                .append('g').classed('text-group', true);
             container
                 .append('g').classed('chart-group', true);
             container
@@ -310,6 +317,20 @@ define(function(require){
                 .attr('stroke', `url(#${lineGradientId})`)
                 .attr('d', line)
                 .attr('clip-path', `url(#${maskingClipId})`);
+        }
+
+        function drawSparklineTitle() {
+            if (title) {
+                svg.selectAll('.sparkline-text').remove();
+            }
+
+            title = svg.selectAll('.text-group')
+              .append('text')
+                .attr('x', chartWidth / 2)
+                .attr('y', chartHeight / 6)
+                .attr('text-anchor', 'middle')
+                .attr('class', 'sparkline-text')
+                .text('Eventbrite growth')
         }
 
         /**

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -93,6 +93,13 @@ define(function(require){
 
             titleEl,
             titleText,
+            titleTextStyle = {
+                'font-size': '22px',
+                'fill': lineGradient[0],
+                'font-family': 'sans-serif',
+                'font-style': 'normal',
+                'font-weight': 400
+            },
 
             markerSize = 1.5,
 
@@ -337,6 +344,11 @@ define(function(require){
                 .attr('y', chartHeight / 6)
                 .attr('text-anchor', 'middle')
                 .attr('class', 'sparkline-text')
+                .style('font-size', titleTextStyle['font-size']) 
+                .style('fill',  titleTextStyle['fill'])
+                .style('font-family', titleTextStyle['font-family'])
+                .style('font-weight', titleTextStyle['font-weight'])
+                .style('font-style', titleTextStyle['font-style'])
                 .text(titleText)
         }
 
@@ -502,6 +514,21 @@ define(function(require){
 
             return this;
         };
+
+        /**
+         * Gets or Sets the text style and font of the title at the top of sparkline
+         * @param  {Object} _x String object to get/set
+         * @return {Object | module} Current margin or Chart module to chain calls
+         * @public
+         */
+        exports.titleTextStyle = function(_x) {
+            if (!arguments.length) {
+                return titleTextStyle;
+            }
+            titleTextStyle = _x;
+
+            return this;
+        }
 
         /**
          * Gets or Sets the valueLabel of the chart

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -321,6 +321,11 @@ define(function(require){
                 .attr('clip-path', `url(#${maskingClipId})`);
         }
 
+        /**
+         * Draws the text element within the text group
+         * Is displayed at the top of sparked area
+         * @private
+         */
         function drawSparklineTitle() {
             if (titleEl) {
                 svg.selectAll('.sparkline-text').remove();

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -13,6 +13,13 @@ define(function(require){
     const {line} = require('./helpers/load');
     const {uniqueId} = require('./helpers/number');
 
+    const DEFAULT_TITLE_TEXT_STYLE = {
+        'font-size': '22px',
+        'font-family': 'sans-serif',
+        'font-style': 'normal',
+        'font-weight': 400
+    }
+
     /**
      * @typedef SparklineChartData
      * @type {Object[]}
@@ -344,11 +351,11 @@ define(function(require){
                 .attr('y', chartHeight / 6)
                 .attr('text-anchor', 'middle')
                 .attr('class', 'sparkline-text')
-                .style('font-size', titleTextStyle['font-size']) 
-                .style('fill',  titleTextStyle['fill'])
-                .style('font-family', titleTextStyle['font-family'])
-                .style('font-weight', titleTextStyle['font-weight'])
-                .style('font-style', titleTextStyle['font-style'])
+                .style('font-size', titleTextStyle['font-size'] || DEFAULT_TITLE_TEXT_STYLE['font-size']) 
+                .style('fill', titleTextStyle['fill'] || lineGradient[0])
+                .style('font-family', titleTextStyle['font-family'] || DEFAULT_TITLE_TEXT_STYLE['font-family'])
+                .style('font-weight', titleTextStyle['font-weight'] || DEFAULT_TITLE_TEXT_STYLE['font-weight'])
+                .style('font-style', titleTextStyle['font-style'] || DEFAULT_TITLE_TEXT_STYLE['font-style'])
                 .text(titleText)
         }
 
@@ -516,10 +523,19 @@ define(function(require){
         };
 
         /**
-         * Gets or Sets the text style and font of the title at the top of sparkline
+         * Gets or Sets the text style object of the title at the top of sparkline.
+         * Using this method, you can set font-family, font-size, font-
          * @param  {Object} _x String object to get/set
          * @return {Object | module} Current margin or Chart module to chain calls
          * @public
+         * @example 
+         * sparkline.titleTextStyle({
+         *    'font-family': 'Roboto',
+         *    'font-size': '1.5em',
+         *    'font-weight': 600,
+         *    'font-style': 'italic',
+         *    'fill': 'lightblue'
+         * })
          */
         exports.titleTextStyle = function(_x) {
             if (!arguments.length) {

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -100,13 +100,7 @@ define(function(require){
 
             titleEl,
             titleText,
-            titleTextStyle = {
-                'font-size': '22px',
-                'fill': lineGradient[0],
-                'font-family': 'sans-serif',
-                'font-style': 'normal',
-                'font-weight': 400
-            },
+            titleTextStyle = DEFAULT_TITLE_TEXT_STYLE,
 
             markerSize = 1.5,
 
@@ -508,7 +502,8 @@ define(function(require){
         };
 
         /**
-         * Gets or Sets the text of the title at the top of sparkline
+         * Gets or Sets the text of the title at the top of sparkline.
+         * To style the title, use the titleTextStyle method below.
          * @param  {String} _x String object to get/set
          * @return {String | module} Current margin or Chart module to chain calls
          * @public
@@ -524,7 +519,24 @@ define(function(require){
 
         /**
          * Gets or Sets the text style object of the title at the top of sparkline.
-         * Using this method, you can set font-family, font-size, font-
+         * Using this method, you can set font-family, font-size, font-weight, font-style,
+         * and color (fill). The default text font settings:
+         * 
+         * <pre>
+         * <code>
+         * {
+         *    'font-family': 'sans-serif',
+         *    'font-size': '16px',
+         *    'font-weight': 400,
+         *    'font-style': 'normal',
+         *    'fill': linearGradient[0]
+         * }
+         * </code>
+         * </pre>
+         * 
+         * You can set attributes individually. Setting just 'font-family'
+         * within the object will set custom 'font-family` while the rest
+         * of the attributes will have the default values provided above.
          * @param  {Object} _x String object to get/set
          * @return {Object | module} Current margin or Chart module to chain calls
          * @public

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -504,8 +504,8 @@ define(function(require){
         /**
          * Gets or Sets the text of the title at the top of sparkline.
          * To style the title, use the titleTextStyle method below.
-         * @param  {String} _x String object to get/set
-         * @return {String | module} Current margin or Chart module to chain calls
+         * @param  {String} _x  String to set
+         * @return {String | module} Current titleText or Chart module to chain calls
          * @public
          */
         exports.titleText = function(_x) {
@@ -537,8 +537,8 @@ define(function(require){
          * You can set attributes individually. Setting just 'font-family'
          * within the object will set custom 'font-family` while the rest
          * of the attributes will have the default values provided above.
-         * @param  {Object} _x String object to get/set
-         * @return {Object | module} Current margin or Chart module to chain calls
+         * @param  {Object} _x  Object with text font configurations
+         * @return {Object | module} Current titleTextStyle or Chart module to chain calls
          * @public
          * @example 
          * sparkline.titleTextStyle({

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -90,7 +90,9 @@ define(function(require){
             line,
             area,
             circle,
-            title,
+
+            titleEl,
+            titleText,
 
             markerSize = 1.5,
 
@@ -320,17 +322,17 @@ define(function(require){
         }
 
         function drawSparklineTitle() {
-            if (title) {
+            if (titleEl) {
                 svg.selectAll('.sparkline-text').remove();
             }
 
-            title = svg.selectAll('.text-group')
+            titleEl = svg.selectAll('.text-group')
               .append('text')
                 .attr('x', chartWidth / 2)
                 .attr('y', chartHeight / 6)
                 .attr('text-anchor', 'middle')
                 .attr('class', 'sparkline-text')
-                .text('Eventbrite growth')
+                .text(titleText)
         }
 
         /**
@@ -354,7 +356,7 @@ define(function(require){
         /**
          * Gets or Sets the areaGradient of the chart
          * @param  {String[]} _x Desired areaGradient for the graph
-         * @return { areaGradient | module} Current areaGradient or Chart module to chain calls
+         * @return {areaGradient | module} Current areaGradient or Chart module to chain calls
          * @public
          */
         exports.areaGradient = function(_x) {
@@ -368,7 +370,7 @@ define(function(require){
         /**
          * Gets or Sets the dateLabel of the chart
          * @param  {Number} _x Desired dateLabel for the graph
-         * @return { dateLabel | module} Current dateLabel or Chart module to chain calls
+         * @return {dateLabel | module} Current dateLabel or Chart module to chain calls
          * @public
          */
         exports.dateLabel = function(_x) {
@@ -383,7 +385,7 @@ define(function(require){
         /**
          * Gets or Sets the duration of the animation
          * @param  {Number} _x Desired animation duration for the graph
-         * @return { dateLabel | module} Current animation duration or Chart module to chain calls
+         * @return {dateLabel | module} Current animation duration or Chart module to chain calls
          * @public
          */
         exports.duration = function(_x) {
@@ -425,7 +427,7 @@ define(function(require){
          * By default this is 'false'
          *
          * @param  {Boolean} _x Desired animation flag
-         * @return { isAnimated | module} Current isAnimated flag or Chart module
+         * @return {isAnimated | module} Current isAnimated flag or Chart module
          * @public
          */
         exports.isAnimated = function(_x) {
@@ -440,7 +442,7 @@ define(function(require){
         /**
          * Gets or Sets the lineGradient of the chart
          * @param  {String[]} _x Desired lineGradient for the graph
-         * @return { lineGradient | module} Current lineGradient or Chart module to chain calls
+         * @return {lineGradient | module} Current lineGradient or Chart module to chain calls
          * @public
          */
         exports.lineGradient = function(_x) {
@@ -454,7 +456,7 @@ define(function(require){
         /**
          * Gets or Sets the loading state of the chart
          * @param  {string} markup Desired markup to show when null data
-         * @return { loadingState | module} Current loading state markup or Chart module to chain calls
+         * @return {loadingState | module} Current loading state markup or Chart module to chain calls
          * @public
          */
         exports.loadingState = function(_markup) {
@@ -469,7 +471,7 @@ define(function(require){
         /**
          * Gets or Sets the margin of the chart
          * @param  {Object} _x Margin object to get/set
-         * @return { margin | module} Current margin or Chart module to chain calls
+         * @return {margin | module} Current margin or Chart module to chain calls
          * @public
          */
         exports.margin = function(_x) {
@@ -482,9 +484,24 @@ define(function(require){
         };
 
         /**
+         * Gets or Sets the text of the title at the top of sparkline
+         * @param  {String} _x String object to get/set
+         * @return {String | module} Current margin or Chart module to chain calls
+         * @public
+         */
+        exports.titleText = function(_x) {
+            if (!arguments.length) {
+                return titleText;
+            }
+            titleText = _x;
+
+            return this;
+        };
+
+        /**
          * Gets or Sets the valueLabel of the chart
          * @param  {Number} _x Desired valueLabel for the graph
-         * @return { valueLabel | module} Current valueLabel or Chart module to chain calls
+         * @return {valueLabel | module} Current valueLabel or Chart module to chain calls
          * @public
          */
         exports.valueLabel = function(_x) {
@@ -499,7 +516,7 @@ define(function(require){
         /**
          * Gets or Sets the width of the chart
          * @param  {Number} _x Desired width for the graph
-         * @return { width | module} Current width or Chart module to chain calls
+         * @return {width | module} Current width or Chart module to chain calls
          * @public
          */
         exports.width = function(_x) {

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -14,10 +14,10 @@ define(function(require){
     const {uniqueId} = require('./helpers/number');
 
     const DEFAULT_TITLE_TEXT_STYLE = {
-        'font-size': '16px',
+        'font-size': '22px',
         'font-family': 'sans-serif',
         'font-style': 'normal',
-        'font-weight': 400
+        'font-weight': 0
     }
 
     /**
@@ -526,8 +526,8 @@ define(function(require){
          * <code>
          * {
          *    'font-family': 'sans-serif',
-         *    'font-size': '16px',
-         *    'font-weight': 400,
+         *    'font-size': '22px',
+         *    'font-weight': 0,
          *    'font-style': 'normal',
          *    'fill': linearGradient[0]
          * }

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -14,7 +14,7 @@ define(function(require){
     const {uniqueId} = require('./helpers/number');
 
     const DEFAULT_TITLE_TEXT_STYLE = {
-        'font-size': '22px',
+        'font-size': '16px',
         'font-family': 'sans-serif',
         'font-style': 'normal',
         'font-weight': 400

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -124,7 +124,7 @@ define(function(require){
                 drawArea();
                 drawEndMarker();
 
-                if (true) {
+                if (titleText) {
                     drawSparklineTitle();
                 }
             });

--- a/test/specs/sparkline.spec.js
+++ b/test/specs/sparkline.spec.js
@@ -274,6 +274,18 @@ define([
                 expect(defaultGradient).not.toBe(testGradient);
                 expect(newGradient).toBe(testGradient);
             });
+
+            it('should provide a titleText getter and setter', () => {
+                let defaultTitleText = sparklineChart.titleText(),
+                testTitleText = 'Budget Growth',
+                newTitleText;
+
+                sparklineChart.titleText(testTitleText);
+                newTitleText = sparklineChart.titleText();
+
+                expect(defaultTitleText).not.toBe(testTitleText);
+                expect(newTitleText).toBe(testTitleText);
+            });
         });
 
         describe('Export chart functionality', () => {

--- a/test/specs/sparkline.spec.js
+++ b/test/specs/sparkline.spec.js
@@ -108,7 +108,7 @@ define([
                 expect(titleTextNode).toHaveAttr('style');
             });
 
-            it('should properl set the text to the text group', () => {
+            it('should properly set the text inside of text node', () => {
                 let expected = 'Tickets Sale';
                 let actual;
                 

--- a/test/specs/sparkline.spec.js
+++ b/test/specs/sparkline.spec.js
@@ -57,6 +57,7 @@ define([
 
         it('should render container and chart groups', () => {
             expect(containerFixture.select('g.container-group').empty()).toBeFalsy();
+            expect(containerFixture.select('g.text-group').empty()).toBeFalsy();
             expect(containerFixture.select('g.chart-group').empty()).toBeFalsy();
             expect(containerFixture.select('g.metadata-group').empty()).toBeFalsy();
         });
@@ -87,6 +88,36 @@ define([
             let actual = _.filter(containerFixture.selectAll('.line-gradient').nodes(), f => f && hasIdWithPrefix(f, 'sparkline-line-gradient')).length;
 
             expect(actual).toEqual(expected);
+        });
+
+        describe('when the title text is set to specified string', () => {
+            
+            it('should create a text node with proper attributes', () => {
+                let titleTextNode;
+                
+                sparklineChart.titleText('text');
+                containerFixture.datum(dataset.data).call(sparklineChart);
+
+                titleTextNode = containerFixture.selectAll('.sparkline-text').node();
+                
+                expect(titleTextNode).toBeInDOM();
+                expect(titleTextNode).toHaveAttr('x');
+                expect(titleTextNode).toHaveAttr('y');
+                expect(titleTextNode).toHaveAttr('text-anchor');
+                expect(titleTextNode).toHaveAttr('class');
+                expect(titleTextNode).toHaveAttr('style');
+            });
+
+            it('should properl set the text to the text group', () => {
+                let expected = 'Tickets Sale';
+                let actual;
+                
+                sparklineChart.titleText(expected);
+                containerFixture.datum(dataset.data).call(sparklineChart);
+                actual = containerFixture.selectAll('.sparkline-text').node().textContent;
+
+                expect(actual).toEqual(expected);
+            });
         });
 
         describe('when reloading with a different dataset', () => {

--- a/test/specs/sparkline.spec.js
+++ b/test/specs/sparkline.spec.js
@@ -286,6 +286,24 @@ define([
                 expect(defaultTitleText).not.toBe(testTitleText);
                 expect(newTitleText).toBe(testTitleText);
             });
+
+            it('should provide a titleTextStyle getter and setter', () => {
+                let defaultTitleTextStyle = sparklineChart.titleTextStyle(),
+                testTitleTextStyle = {
+                    'font-family': 'Verdana',
+                    'font-size': '32px',
+                    'font-weight': 200,
+                    'font-style': 'italic',
+                    'fill': 'green',
+                },
+                newTitleTextStyle;
+
+                sparklineChart.titleTextStyle(testTitleTextStyle);
+                newTitleTextStyle = sparklineChart.titleTextStyle();
+
+                expect(defaultTitleTextStyle).not.toEqual(testTitleTextStyle);
+                expect(newTitleTextStyle).toEqual(testTitleTextStyle);
+            });
         });
 
         describe('Export chart functionality', () => {


### PR DESCRIPTION
After looking at the shared image in #100, it made sense to me to give Sparkline chart ability to have its own title with custom font settings supplied by the user (the default for each font attribute is applied if not given to the object). 

## Description
Proposed feature to allow users to add a "title" text at the top (with possible align settings in the future). Added two new methods to Sparkline's API:
* `titleText` - sets the string of the title text
* `titleTextStyle` - sets the text font style settings like `font-weight`, `fill`, `font-family`, and `font-style` (more may be added).
Also, added a new `text-group` to the container set which appends the title text if the `titleText` is set.

## Motivation and Context
Partially due to https://github.com/eventbrite/britecharts/issues/100

## How Has This Been Tested?
Added tests to `sparkline.unit.spec.js` that tests the setters and getters of the new methods and tests their presence in the dom as well.

## Screenshots (if appropriate):
![screen shot 2018-02-24 at 2 07 59 am](https://user-images.githubusercontent.com/31934144/36636739-5c8f5634-1981-11e8-8f7c-2f448ec20d37.png)

![screen shot 2018-02-24 at 2 09 37 am](https://user-images.githubusercontent.com/31934144/36636740-63589fb6-1981-11e8-8cb4-5167d39e2540.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
