### PR TITLE
Feature - custom click handler with data point for Grouped Bar

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,8 @@ module.exports = function(config) {
         // list of files / patterns to load in the browser
         files: [
             'tests_index.js',
-            {pattern: 'test/fixtures/*.html', watched: true, served: true, included: false}
+            {pattern: 'test/fixtures/*.html', watched: true, served: true, included: false},
+            './node_modules/phantomjs-polyfill-find/find-polyfill.js'
         ],
 
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "visualizations",
     "data-visualization",
     "interactive-visualizations"
-
   ],
   "author": "Eventbrite",
   "license": "Apache-2.0",
@@ -116,6 +115,7 @@
     "karma-webpack": "^2.0.5",
     "load-grunt-tasks": "^3.5.2",
     "moment": "^2.17.0",
+    "phantomjs-polyfill-find": "ptim/phantomjs-polyfill-find",
     "prismjs": "^1.6.0",
     "pubsub-js": "^1.5.7",
     "requirejs-plugins": "^1.0.2",

--- a/src/charts/grouped-bar.js
+++ b/src/charts/grouped-bar.js
@@ -144,7 +144,12 @@ define(function (require) {
             isAnimated = false,
 
             // events
-            dispatcher = d3Dispatch.dispatch('customMouseOver', 'customMouseOut', 'customMouseMove');
+            dispatcher = d3Dispatch.dispatch(
+                'customMouseOver',
+                'customMouseOut',
+                'customMouseMove',
+                'customClick'
+            );
 
         /**
          * This function creates the graph using the selection and data provided
@@ -185,7 +190,10 @@ define(function (require) {
                     })
                     .on('mousemove',  function(d) {
                         handleMouseMove(this, d);
-                    });
+                    })
+                    .on('click',  function(d) {
+                        handleCustomClick(this, d);
+                    });;
             }
 
             svg.selectAll('.bar')
@@ -691,6 +699,17 @@ define(function (require) {
         }
 
         /**
+         * Click handler, shows data that was clicked and passes to the user
+         * @private
+         */
+        function handleCustomClick (e, d) {
+            let [mouseX, mouseY] = getMousePosition(e);
+            let dataPoint = isHorizontal ? getNearestDataPoint2(mouseY) : getNearestDataPoint(mouseX);
+
+            dispatcher.call('customClick', e, dataPoint, d3Selection.mouse(e));
+        }
+
+        /**
          * MouseOut handler, hides overlay and removes active class on verticalMarkerLine
          * It also resets the container of the vertical marker
          * @private
@@ -976,7 +995,7 @@ define(function (require) {
         /**
          * Exposes an 'on' method that acts as a bridge with the event dispatcher
          * We are going to expose this events:
-         * customMouseOver, customMouseMove and customMouseOut
+         * customMouseOver, customMouseMove, customMouseOut, and customClick
          *
          * @return {module} Bar Chart
          * @public

--- a/test/specs/grouped-bar.spec.js
+++ b/test/specs/grouped-bar.spec.js
@@ -358,6 +358,20 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
             });
         });
 
+        describe('when clicking on a bar', function() {
+
+            it('should trigger a callback', () => {
+                let chart = containerFixture.selectAll('.grouped-bar');
+                let callbackSpy = jasmine.createSpy('callback');
+
+                groupedBarChart.on('customClick', callbackSpy);
+                chart.dispatch('click');
+
+                expect(callbackSpy.calls.count()).toBe(1);
+                expect(callbackSpy.calls.allArgs()[0].length).toBe(2);
+            })
+        });
+
         describe('when hovering', function() {
 
             it('mouseover should trigger a callback', () => {

--- a/test/specs/grouped-bar.spec.js
+++ b/test/specs/grouped-bar.spec.js
@@ -80,20 +80,6 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
             expect(actual).toEqual(expected);
         });
 
-        describe('when clicking on a bar', () => {
-
-            it('should trigger a callback', function() {
-                let chart = containerFixture.selectAll('.grouped-bar');
-                let callbackSpy = jasmine.createSpy('callback');
-
-                groupedBarChart.on('customClick', callbackSpy);
-                chart.dispatch('click');
-
-                expect(callbackSpy.calls.count()).toBe(1);
-                expect(callbackSpy.calls.allArgs()[0].length).toBe(2);
-            })
-        });
-
         describe('when reloading with a two sources dataset', () => {
 
             it('should render in the same svg', function() {
@@ -370,6 +356,20 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
                 expect(defaultYAxisLabelOffset).not.toBe(newYAxisLabelOffset);
                 expect(newYAxisLabelOffset).toBe(testYAxisLabelOffset);
             });
+        });
+
+        describe('when clicking on a bar', () => {
+
+            it('should trigger a callback', function() {
+                let chart = containerFixture.select('.grouped-bar');
+                let callbackSpy = jasmine.createSpy('customClick');
+
+                groupedBarChart.on('customClick', callbackSpy);
+                chart.dispatch('click');
+
+                expect(callbackSpy.calls.count()).toBe(1);
+                expect(callbackSpy.calls.allArgs()[0].length).toBe(2);
+            })
         });
 
         describe('when hovering', function() {

--- a/test/specs/grouped-bar.spec.js
+++ b/test/specs/grouped-bar.spec.js
@@ -80,6 +80,20 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
             expect(actual).toEqual(expected);
         });
 
+        describe('when clicking on a bar', () => {
+
+            it('should trigger a callback', function() {
+                let chart = containerFixture.selectAll('.grouped-bar');
+                let callbackSpy = jasmine.createSpy('callback');
+
+                groupedBarChart.on('customClick', callbackSpy);
+                chart.dispatch('click');
+
+                expect(callbackSpy.calls.count()).toBe(1);
+                expect(callbackSpy.calls.allArgs()[0].length).toBe(2);
+            })
+        });
+
         describe('when reloading with a two sources dataset', () => {
 
             it('should render in the same svg', function() {

--- a/test/specs/grouped-bar.spec.js
+++ b/test/specs/grouped-bar.spec.js
@@ -80,6 +80,20 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
             expect(actual).toEqual(expected);
         });
 
+        describe('when clicking on a bar', function() {
+
+            it('should trigger a callback', () => {
+                let chart = containerFixture.selectAll('.grouped-bar');
+                let callbackSpy = jasmine.createSpy('callback');
+
+                groupedBarChart.on('customClick', callbackSpy);
+                chart.dispatch('click');
+
+                expect(callbackSpy.calls.count()).toBe(1);
+                expect(callbackSpy.calls.allArgs()[0].length).toBe(2);
+            })
+        });
+
         describe('when reloading with a two sources dataset', () => {
 
             it('should render in the same svg', function() {
@@ -356,20 +370,6 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
                 expect(defaultYAxisLabelOffset).not.toBe(newYAxisLabelOffset);
                 expect(newYAxisLabelOffset).toBe(testYAxisLabelOffset);
             });
-        });
-
-        describe('when clicking on a bar', function() {
-
-            it('should trigger a callback', () => {
-                let chart = containerFixture.selectAll('.grouped-bar');
-                let callbackSpy = jasmine.createSpy('callback');
-
-                groupedBarChart.on('customClick', callbackSpy);
-                chart.dispatch('click');
-
-                expect(callbackSpy.calls.count()).toBe(1);
-                expect(callbackSpy.calls.allArgs()[0].length).toBe(2);
-            })
         });
 
         describe('when hovering', function() {

--- a/test/specs/grouped-bar.spec.js
+++ b/test/specs/grouped-bar.spec.js
@@ -80,20 +80,6 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
             expect(actual).toEqual(expected);
         });
 
-        describe('when clicking on a bar', function() {
-
-            it('should trigger a callback', () => {
-                let chart = containerFixture.selectAll('.grouped-bar');
-                let callbackSpy = jasmine.createSpy('callback');
-
-                groupedBarChart.on('customClick', callbackSpy);
-                chart.dispatch('click');
-
-                expect(callbackSpy.calls.count()).toBe(1);
-                expect(callbackSpy.calls.allArgs()[0].length).toBe(2);
-            })
-        });
-
         describe('when reloading with a two sources dataset', () => {
 
             it('should render in the same svg', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5588,6 +5588,10 @@ performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
+phantomjs-polyfill-find@ptim/phantomjs-polyfill-find:
+  version "0.0.1"
+  resolved "https://codeload.github.com/ptim/phantomjs-polyfill-find/tar.gz/026b69dcabe743265f5214775e42f8d1e8aabedc"
+
 phantomjs-prebuilt@^2.1.7:
   version "2.1.14"
   resolved "https://registry.yarnpkg.com/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.14.tgz#d53d311fcfb7d1d08ddb24014558f1188c516da0"


### PR DESCRIPTION
Added a custom `click` handler for the Grouped Bar chart.

## Description
Added a new event to dispatcher called `customClick` with the handler that passes the clicked bar data point via callback for the user to use (see logs in the screenshot).

*Update:* Had to install `Array.prototype.find` ship. It needs to be included in `PhantomJS` to accept the `Array.prototype.find` method used in `getNearestDataPoint` function here https://github.com/eventbrite/britecharts/blob/master/src/charts/grouped-bar.js#L607

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/534

## How Has This Been Tested?
Added new test that checks if function was invoked (similar to the `mouseover` and other events)

## Screenshots (if appropriate):
![grouped_bar_custom_click](https://user-images.githubusercontent.com/31934144/36690891-884264fc-1ae8-11e8-89b4-9d85e1fc6e0f.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
