### PR TITLE
Click handler for stacked bar chart

### DIFF
--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -148,7 +148,12 @@ define(function(require){
             isAnimated = false,
 
             // events
-            dispatcher = d3Dispatch.dispatch('customMouseOver', 'customMouseOut', 'customMouseMove');
+            dispatcher = d3Dispatch.dispatch(
+                'customMouseOver',
+                'customMouseOut',
+                'customMouseMove',
+                'customClick'
+            );
 
         /**
          * This function creates the graph using the selection and data provided
@@ -189,6 +194,9 @@ define(function(require){
                     })
                     .on('mousemove',  function(d) {
                         handleMouseMove(this, d);
+                    })
+                    .on('click',  function(d) {
+                        handleClick(this, d);
                     });
             }
 
@@ -665,6 +673,19 @@ define(function(require){
         }
 
         /**
+         * Click handler, passes the data point of the clicked bar 
+         * (or it's nearest point)
+         * @private
+         */
+
+         function handleClick(e) {
+            let [mouseX, mouseY] = getMousePosition(e);
+            let dataPoint = isHorizontal ? getNearestDataPoint2(mouseY) : getNearestDataPoint(mouseX);
+
+            dispatcher.call('customClick', e, dataPoint, d3Selection.mouse(e));
+         }
+
+        /**
          * MouseOut handler, hides overlay and removes active class on verticalMarkerLine
          * It also resets the container of the vertical marker
          * @private
@@ -1036,7 +1057,7 @@ define(function(require){
         /**
          * Exposes an 'on' method that acts as a bridge with the event dispatcher
          * We are going to expose this events:
-         * customMouseOver, customMouseMove and customMouseOut
+         * customMouseOver, customMouseMove, customMouseOut, and customClick
          *
          * @return {module} Bar Chart
          * @public

--- a/test/specs/grouped-bar.spec.js
+++ b/test/specs/grouped-bar.spec.js
@@ -362,7 +362,7 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
 
             it('should trigger a callback', function() {
                 let chart = containerFixture.select('.grouped-bar');
-                let callbackSpy = jasmine.createSpy('customClick');
+                let callbackSpy = jasmine.createSpy('callback');
 
                 groupedBarChart.on('customClick', callbackSpy);
                 chart.dispatch('click');

--- a/test/specs/stacked-bar.spec.js
+++ b/test/specs/stacked-bar.spec.js
@@ -391,6 +391,20 @@ define(['d3', 'stacked-bar', 'stackedBarDataBuilder'], function(d3, chart, dataB
             });
         });
 
+        describe('when clicking on a bar', () => {
+
+            it('should trigger a callback', function() {
+                let chart = containerFixture.select('.stacked-bar');
+                let callbackSpy = jasmine.createSpy('callback');
+
+                stackedBarChart.on('customClick', callbackSpy);
+                chart.dispatch('click');
+
+                expect(callbackSpy.calls.count()).toBe(1);
+                expect(callbackSpy.calls.allArgs()[0].length).toBe(2);
+            })
+        });
+
         describe('when hovering', function() {
 
             it('mouseover should trigger a callback', () => {


### PR DESCRIPTION
## Description
Added stacked bar `customClick` handler that returns the bar clicked (or nearest bar to the clicked point).

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/534

## How Has This Been Tested?
Added new test for `customClick` event handler callback.

## Screenshots (if appropriate):
![britecharts_stacked_area_click](https://user-images.githubusercontent.com/31934144/36714900-c92a41a0-1b48-11e8-96ea-9be9c7bfc614.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
