### PR TITLE
Cleaning gridlines before rendering to fix gridline bug when reloading

### DIFF
--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -560,6 +560,10 @@ define(function(require) {
          * @return void
          */
         function drawGridLines() {
+            svg.select('.grid-lines-group')
+                .selectAll('line')
+                .remove();
+
             if (isHorizontal) {
                 drawHorizontalGridLines();
             } else {

--- a/src/charts/grouped-bar.js
+++ b/src/charts/grouped-bar.js
@@ -452,6 +452,10 @@ define(function (require) {
         function drawGridLines() {
             let scale = isHorizontal ? xScale : yScale;
 
+            svg.select('.grid-lines-group')
+                .selectAll('line')
+                .remove();
+
             if (grid === 'horizontal' || grid === 'full') {
                 svg.select('.grid-lines-group')
                     .selectAll('line.horizontal-grid-line')

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -625,7 +625,6 @@ define(function(require){
          * @return void
          */
         function drawGridLines(xTicks, yTicks) {
-
             svg.select('.grid-lines-group')
                 .selectAll('line')
                 .remove();

--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -408,6 +408,10 @@ define(function(require){
         function drawGridLines() {
             let scale = isHorizontal ? xScale : yScale;
 
+            svg.select('.grid-lines-group')
+                .selectAll('line')
+                .remove();
+
             if (grid === 'horizontal' || grid === 'full') {
                 svg.select('.grid-lines-group')
                     .selectAll('line.horizontal-grid-line')
@@ -673,7 +677,7 @@ define(function(require){
         }
 
         /**
-         * Click handler, passes the data point of the clicked bar 
+         * Click handler, passes the data point of the clicked bar
          * (or it's nearest point)
          * @private
          */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding cleaning logic to the grid lines in all bar charts

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/eventbrite/britecharts/issues/487

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually, ran tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
