### PR TITLE
RC-3.0 Feature - method for manually setting empty states

### DIFF
--- a/demos/demo-donut.js
+++ b/demos/demo-donut.js
@@ -41,6 +41,7 @@ function createDonutChart(optionalColorSchema) {
             .height(containerWidth)
             .externalRadius(containerWidth/2.5)
             .internalRadius(containerWidth/5)
+            .shouldShowEmptyState(true)
             .on('customMouseOver', function(data) {
                 legendChart.highlight(data.data.id);
             })

--- a/demos/demo-donut.js
+++ b/demos/demo-donut.js
@@ -41,7 +41,6 @@ function createDonutChart(optionalColorSchema) {
             .height(containerWidth)
             .externalRadius(containerWidth/2.5)
             .internalRadius(containerWidth/5)
-            .shouldShowEmptyState(true)
             .on('customMouseOver', function(data) {
                 legendChart.highlight(data.data.id);
             })

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -601,7 +601,7 @@ define(function(require) {
 
         /**
          * Gets or Sets the emptySliceColor of the chart. 
-         * If data is mepty or shouldShowEmptyState is set to true, the chart will render 
+         * If data is empty or shouldShowEmptyState is set to true, the chart will render 
          * an empty slice with a given color (light gray by default)
          * @param  {Object} _x emptyDataConfig object to get/set
          * @return {Object | module} Current config for when chart data is an empty array

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -319,7 +319,7 @@ define(function(require) {
          * @private
          */
         function drawLegend(obj) {
-            if (obj.data) {
+            if (obj.data && !shouldShowEmptyState) {
 
                 svg.select('.donut-text')
                     .text(() => centeredTextFunction(obj.data))

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -822,7 +822,6 @@ define(function(require) {
 
         /**
          * Gets or Sets the shouldShowEmptyState state of the chart
-         * The default value is -60
          * @param  {Boolean} _x Whether or not to set chart to empty state
          * @return {Boolean | module} Current shouldShowEmptyState or Chart module to chain calls
          * @public

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -265,7 +265,7 @@ define(function(require) {
                 isEmpty = true;
             }
 
-            dataWithPercentages = cleanData.map((d) => {
+            dataWithPercentages = shouldShowEmptyState ? [] : cleanData.map((d) => {
                 d.percentage = String(d.percentage || calculatePercent(d[quantityLabel], totalQuantity, percentageFormat));
 
                 return d;

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -90,17 +90,14 @@ define(function(require) {
             svg,
 
             isAnimated = false,
-            isEmpty = false,
             shouldShowEmptyState = false,
 
             highlightedSliceId,
             highlightedSlice,
             hasFixedHighlightedSlice = false,
 
-            emptyDataConfig = {
-                emptySliceColor: '#EFF2F5',
-                showEmptySlice: false
-            },
+
+            emptySliceColor = '#EFF2F5',
 
             quantityLabel = 'quantity',
             nameLabel = 'name',
@@ -157,7 +154,7 @@ define(function(require) {
                 if (highlightedSliceId) {
                     initHighlightSlice();
                 }
-                if ((isEmpty && emptyDataConfig.showEmptySlice) || shouldShowEmptyState) {
+                if (shouldShowEmptyState) {
                     drawEmptySlice();
                 }
             });
@@ -261,11 +258,12 @@ define(function(require) {
 
             let totalQuantity = sumValues(cleanData);
 
-            if (totalQuantity === 0 && emptyDataConfig.showEmptySlice) {
-                isEmpty = true;
+
+            if (totalQuantity === 0) {
+                shouldShowEmptyState = true;
             }
 
-            dataWithPercentages = shouldShowEmptyState ? [] : cleanData.map((d) => {
+            dataWithPercentages = cleanData.map((d) => {
                 d.percentage = String(d.percentage || calculatePercent(d[quantityLabel], totalQuantity, percentageFormat));
 
                 return d;
@@ -304,7 +302,7 @@ define(function(require) {
                   .append('path');
 
             newSlices.merge(slices)
-                .attr('fill', emptyDataConfig.emptySliceColor)
+                .attr('fill', emptySliceColor)
                 .attr('d', shape)
                 .transition()
                 .ease(ease)
@@ -595,19 +593,19 @@ define(function(require) {
         };
 
         /**
-         * Gets or Sets the emptyDataConfig of the chart. If set and data is empty (quantity
-         * adds up to zero or there are no entries), the chart will render an empty slice
-         * with a given color (light gray by default)
+         * Gets or Sets the emptySliceColor of the chart. 
+         * If shouldShowEmptyState is set to true, the chart will render 
+         * an empty slice with a given color (light gray by default)
          * @param  {Object} _x emptyDataConfig object to get/set
-         * @return { Object | module} Current config for when chart data is an empty array
+         * @return {Object | module} Current config for when chart data is an empty array
          * @public
-         * @example donutChart.emptyDataConfig({showEmptySlice: true, emptySliceColor: '#000000'})
+         * @example donutChart.emptySliceColor('#000000')
          */
-        exports.emptyDataConfig = function(_x) {
+        exports.emptySliceColor = function(_x) {
             if (!arguments.length) {
-                return emptyDataConfig;
+                return emptySliceColor;
             }
-            emptyDataConfig = _x;
+            emptySliceColor = _x;
 
             return this;
         };

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -257,7 +257,6 @@ define(function(require) {
 
             let totalQuantity = sumValues(cleanData);
 
-
             if (totalQuantity === 0) {
                 shouldShowEmptyState = true;
             }
@@ -593,7 +592,7 @@ define(function(require) {
 
         /**
          * Gets or Sets the emptySliceColor of the chart. 
-         * If shouldShowEmptyState is set to true, the chart will render 
+         * If data is mepty or shouldShowEmptyState is set to true, the chart will render 
          * an empty slice with a given color (light gray by default)
          * @param  {Object} _x emptyDataConfig object to get/set
          * @return {Object | module} Current config for when chart data is an empty array
@@ -621,7 +620,7 @@ define(function(require) {
 
         /**
          * Gets or Sets the externalRadius of the chart
-         * @param  {Number} _x              ExternalRadius number to get/set
+         * @param  {Number}                 ExternalRadius number to get/set
          * @return { (Number | Module) }    Current externalRadius or Donut Chart module to chain calls
          * @public
          */

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -319,7 +319,7 @@ define(function(require) {
          * @private
          */
         function drawLegend(obj) {
-            if (obj.data && !shouldShowEmptyState) {
+            if (obj.data) {
 
                 svg.select('.donut-text')
                     .text(() => centeredTextFunction(obj.data))

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -91,6 +91,7 @@ define(function(require) {
 
             isAnimated = false,
             isEmpty = false,
+            shouldShowEmptyState = false,
 
             highlightedSliceId,
             highlightedSlice,
@@ -156,7 +157,7 @@ define(function(require) {
                 if (highlightedSliceId) {
                     initHighlightSlice();
                 }
-                if (isEmpty && emptyDataConfig.showEmptySlice) {
+                if ((isEmpty && emptyDataConfig.showEmptySlice) || shouldShowEmptyState) {
                     drawEmptySlice();
                 }
             });
@@ -818,6 +819,23 @@ define(function(require) {
 
             return this;
         };
+
+        /**
+         * Gets or Sets the shouldShowEmptyState state of the chart
+         * The default value is -60
+         * @param  {Boolean} _x Whether or not to set chart to empty state
+         * @return {Boolean | module} Current shouldShowEmptyState or Chart module to chain calls
+         * @public
+         * @example donutChart.shouldShowEmptyState(true)
+         */
+        exports.shouldShowEmptyState = function(_x) {
+            if (!arguments.length) {
+                return shouldShowEmptyState;
+            }
+            shouldShowEmptyState = _x;
+
+            return this;
+        }
 
         /**
          * Gets or Sets the width of the chart

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -96,7 +96,6 @@ define(function(require) {
             highlightedSlice,
             hasFixedHighlightedSlice = false,
 
-
             emptySliceColor = '#EFF2F5',
 
             quantityLabel = 'quantity',

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -17,6 +17,10 @@ define(function(require) {
     const {emptyDonutData} =require('./helpers/constants');
     const {donut} = require('./helpers/load');
 
+    const DEFAULT_LEGEND_TEXT_PARAMS = {
+        percentage: '0',
+        name: ''
+    }
 
     /**
      * @typedef DonutChartData
@@ -109,7 +113,7 @@ define(function(require) {
             colorScale,
             colorSchema = colorHelper.colorSchemas.britecharts,
 
-            centeredTextFunction = (d) => `${d.percentage}% ${d.name}`,
+            centeredTextFunction = (d = DEFAULT_LEGEND_TEXT_PARAMS) => `${d.percentage}% ${d.name}`,
 
             // utils
             storeAngle = function(d) {
@@ -318,9 +322,14 @@ define(function(require) {
          */
         function drawLegend(obj) {
             if (obj.data) {
+                let centeredTextFunctionText = centeredTextFunction(obj.data);
+
+                if (shouldShowEmptyState) {
+                    centeredTextFunctionText = centeredTextFunction();
+                }
 
                 svg.select('.donut-text')
-                    .text(() => centeredTextFunction(obj.data))
+                    .text(centeredTextFunctionText)
                     .attr('dy', '.2em')
                     .attr('text-anchor', 'middle');
 

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -1349,6 +1349,23 @@ define(function(require){
         exports.axisTimeCombinations = axisTimeCombinations;
 
         /**
+         * Gets or Sets the shouldShowEmptyState state of the chart
+         * The default value is -60
+         * @param  {Boolean} _x Whether or not to set chart to empty state
+         * @return {Boolean | module} Current shouldShowEmptyState or Chart module to chain calls
+         * @public
+         * @example stackedArea.shouldShowEmptyState(true)
+         */
+        exports.shouldShowEmptyState = function(_x) {
+            if (!arguments.length) {
+                return shouldShowEmptyState;
+            }
+            shouldShowEmptyState = _x;
+
+            return this;
+        }
+
+        /**
          * Gets or Sets the valueLabel of the chart
          * @param  {Number} _x Desired valueLabel for the graph
          * @return { valueLabel | module} Current valueLabel or Chart module to chain calls
@@ -1482,24 +1499,6 @@ define(function(require){
 
             return this;
         }
-
-        /**
-         * Gets or Sets the shouldShowEmptyState state of the chart
-         * The default value is -60
-         * @param  {Boolean} _x Whether or not to set chart to empty state
-         * @return {Boolean | module} Current shouldShowEmptyState or Chart module to chain calls
-         * @public
-         * @example stackedArea.shouldShowEmptyState(true)
-         */
-        exports.shouldShowEmptyState = function(_x) {
-            if (!arguments.length) {
-                return shouldShowEmptyState;
-            }
-            shouldShowEmptyState = _x;
-
-            return this;
-        }
-
 
         return exports;
     };

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -523,10 +523,9 @@ define(function(require){
          * @private
          */
         function cleanData(originalData) {
-            originalData = 
-                originalData.length === 0 || shouldShowEmptyState
-                    ? createFakeData()
-                    : originalData;
+            originalData = shouldShowEmptyState
+                ? createFakeData()
+                : originalData;
 
             return originalData.reduce((acc, d) => {
                 d.date = new Date(d[dateLabel]),

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -1350,7 +1350,6 @@ define(function(require){
 
         /**
          * Gets or Sets the shouldShowEmptyState state of the chart
-         * The default value is -60
          * @param  {Boolean} _x Whether or not to set chart to empty state
          * @return {Boolean | module} Current shouldShowEmptyState or Chart module to chain calls
          * @public

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -163,6 +163,8 @@ define(function(require){
             dataByDateFormatted,
             dataByDateZeroed,
 
+            shouldShowEmptyState = false,
+
             verticalGridLines,
             horizontalGridLines,
             grid = null,
@@ -521,7 +523,10 @@ define(function(require){
          * @private
          */
         function cleanData(originalData) {
-            originalData = originalData.length === 0 ? createFakeData() : originalData;
+            originalData = 
+                originalData.length === 0 || shouldShowEmptyState
+                    ? createFakeData()
+                    : originalData;
 
             return originalData.reduce((acc, d) => {
                 d.date = new Date(d[dateLabel]),
@@ -1474,6 +1479,23 @@ define(function(require){
                 return yAxisLabelOffset;
             }
             yAxisLabelOffset = _x;
+
+            return this;
+        }
+
+        /**
+         * Gets or Sets the shouldShowEmptyState state of the chart
+         * The default value is -60
+         * @param  {Boolean} _x Whether or not to set chart to empty state
+         * @return {Boolean | module} Current shouldShowEmptyState or Chart module to chain calls
+         * @public
+         * @example stackedArea.shouldShowEmptyState(true)
+         */
+        exports.shouldShowEmptyState = function(_x) {
+            if (!arguments.length) {
+                return shouldShowEmptyState;
+            }
+            shouldShowEmptyState = _x;
 
             return this;
         }

--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -675,8 +675,8 @@ define(function(require){
 
         /**
          * Gets or Sets the number format for the value displayed on the tooltip
-         * @param  {string} Desired number format
-         * @return {string | module} Current numberFormat or Chart module to chain calls
+         * @param  {String} Desired number format
+         * @return {String | module} Current numberFormat or Chart module to chain calls
          * @public
          */
         exports.numberFormat = function(_x) {

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -174,18 +174,15 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
 
             });
 
-            describe('when data is empty and emptyDataConfig.showEmptySlice', () => {
+            describe('when data is empty', () => {
 
                 it('should render a single filler slice', () => {
                     let actual;
                     let expected = 1;
 
-                    let emptyDataConfig = {
-                        emptySliceColor: '#000000',
-                        showEmptySlice: true,
-                    }
+                    let emptySliceColor = '#000000';
 
-                    donutChart.emptyDataConfig(emptyDataConfig);
+                    donutChart.emptySliceColor(emptySliceColor);
                     containerFixture.datum([]).call(donutChart);
 
                     actual = containerFixture.selectAll('.donut-chart .arc path').nodes().length;
@@ -198,12 +195,9 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                     let actual;
                     let expected = '#000000';
 
-                    let emptyDataConfig = {
-                        emptySliceColor: expected,
-                        showEmptySlice: true,
-                    }
+                    let emptySliceColor = '#000000';
 
-                    donutChart.emptyDataConfig(emptyDataConfig);
+                    donutChart.emptySliceColor(emptySliceColor);
                     containerFixture.datum([]).call(donutChart);
 
                     let paths = containerFixture.selectAll('.donut-chart .arc path').nodes();

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -116,7 +116,7 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
 
                 it('percentage label should be 0%', () => {
                     let actual;
-                    let expected = '0.0%';
+                    let expected = '0%';
 
                     let emptySliceColor = '#EFF2F5';
 

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -504,6 +504,18 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                     expect(previous).not.toBe(expected);
                     expect(actual).toBe(expected);
                 });
+
+                it('should provide shouldShowEmptyState getter and setter', () => {
+                    let previous = donutChart.shouldShowEmptyState(),
+                        expected = true,
+                        actual;
+
+                    donutChart.shouldShowEmptyState(expected);
+                    actual = donutChart.shouldShowEmptyState();
+
+                    expect(previous).not.toBe(expected);
+                    expect(actual).toBe(expected);
+                });
             });
 
             describe('when mouse events are triggered', () => {

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -112,23 +112,20 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
             });
 
 
-            describe('when all sections are zero and emptyDataConfig.showEmptySlice', () => {
+            describe('when all sections are zero', () => {
 
                 it('percentage label should be 0%', () => {
                     let actual;
                     let expected = '0.0%';
 
-                    let emptyDataConfig = {
-                        emptySliceColor: '#EFF2F5',
-                        showEmptySlice: true,
-                    }
+                    let emptySliceColor = '#EFF2F5';
 
                     let dataset = aTestDataSet()
                         .withAllTopicsAtZero()
                         .build();
 
-                    donutChart.highlightSliceById(11)
-                    donutChart.emptyDataConfig(emptyDataConfig);
+                    donutChart.highlightSliceById(11);
+                    donutChart.emptySliceColor(emptySliceColor);
                     containerFixture.datum(dataset).call(donutChart);
 
                     let textNodes = containerFixture.select('text.donut-text .value').nodes();
@@ -143,16 +140,13 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                     let actual;
                     let expected = 1;
 
-                    let emptyDataConfig = {
-                        emptySliceColor: '#EFF2F5',
-                        showEmptySlice: true,
-                    }
+                    let emptySliceColor = '#EFF2F5';
 
                     let dataset = aTestDataSet()
                         .withAllTopicsAtZero()
                         .build();
 
-                    donutChart.emptyDataConfig(emptyDataConfig);
+                    donutChart.emptySliceColor(emptySliceColor);
                     containerFixture.datum(dataset).call(donutChart);
                     actual = containerFixture.selectAll('.donut-chart .arc path').nodes().length;
 
@@ -160,18 +154,14 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
 
                 });
 
-                it('should fill the empty slice with emptyDataConfig.emptySliceColor', () => {
+                it('should fill the empty slice with emptySliceColor', () => {
                     let actual;
                     let expected = '#000000';
-                    let emptyDataConfig = {
-                        emptySliceColor: expected,
-                        showEmptySlice: true,
-                    }
                     let dataset = aTestDataSet()
                         .withAllTopicsAtZero()
                         .build();
 
-                    donutChart.emptyDataConfig(emptyDataConfig);
+                    donutChart.emptySliceColor(expected);
                     containerFixture.datum(dataset).call(donutChart);
 
                     let paths = containerFixture.selectAll('.donut-chart .arc path').nodes();

--- a/test/specs/stacked-area.spec.js
+++ b/test/specs/stacked-area.spec.js
@@ -518,6 +518,18 @@ define([
                 expect(defaultYAxisLabelOffset).not.toBe(newYAxisLabelOffset);
                 expect(newYAxisLabelOffset).toBe(testYAxisLabelOffset);
             });
+
+            it('should provide shouldShowEmptyState getter and setter', () => {
+                let defaultShouldShowEmptyState =  stackedAreaChart.yAxisLabelOffset(),
+                    testShouldShowEmptyState = true,
+                    newShouldShowEmptyState;
+
+                stackedAreaChart.yAxisLabelOffset(testShouldShowEmptyState);
+                newShouldShowEmptyState = stackedAreaChart.yAxisLabelOffset();
+
+                expect(defaultShouldShowEmptyState).not.toBe(newShouldShowEmptyState);
+                expect(newShouldShowEmptyState).toBe(testShouldShowEmptyState);
+            });
         });
 
         describe('Aspect Ratio', function() {

--- a/test/specs/stacked-area.spec.js
+++ b/test/specs/stacked-area.spec.js
@@ -179,8 +179,8 @@ define([
         });
 
 
-        it('should be able to render even when data is length 0', () => {
-            expect(() => containerFixture.datum([]).call(stackedAreaChart)).not.toThrow();
+        it('should not be able to render when data is length 0', () => {
+            expect(() => containerFixture.datum([]).call(stackedAreaChart)).toThrow();
         });
 
         // Add test for highlight circles events


### PR DESCRIPTION
Added `shouldShowEmptyState` method to `donut` and `stacked-area` APIs to set the empty state manually (even if data is given) to see the empty states as described in https://github.com/eventbrite/britecharts/issues/483

## Description
Empty state will be known using `shouldShowEmptyState`. For the donut chart, it will show an empty slice with no info for the centered text (we can switch to make it show 0% if needed).
*Update:* changed logic in `drawLegend` to show `0%` if `shouldShowEmptyState` is `true`

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/483

## How Has This Been Tested?
Added two new setter/getter, one for each chart.

## Screenshots (if appropriate):
`donut.sholdShowEmptyState(true)`:
<img width="1257" alt="screen shot 2018-02-28 at 3 40 20 pm" src="https://user-images.githubusercontent.com/31934144/36819349-0966e72c-1c9e-11e8-96c1-6d8250d9a7a3.png">



`stackedArea.sholdShowEmptyState(true)`:
<img width="853" alt="screen shot 2018-02-27 at 5 16 44 pm" src="https://user-images.githubusercontent.com/31934144/36765406-e81c196a-1be5-11e8-85a3-afcf49871ffc.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
