### PR TITLE
Fixed data refresh bug

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -638,16 +638,17 @@ define(function(require){
             lines = svg.select('.chart-group').selectAll('.line')
                 .data(dataByTopic, getTopic);
 
-            paths = lines.enter()
+            paths = lines.merge(lines.enter()
               .append('g')
                 .attr('class', 'topic')
-                  .append('path')
-                    .attr('class', 'line')
-                    .attr('id', ({topic}) => topic)
-                    .attr('d', ({dates}) => topicLine(dates))
-                    .style('stroke', (d) => (
-                        dataByTopic.length === 1 ? `url(#${lineGradientId})` : getLineColor(d)
-                    ));
+              .append('path')
+                .attr('class', 'line')
+                .attr('id', ({topic}) => topic)
+                .attr('d', ({dates}) => topicLine(dates))
+                .style('stroke', (d) => (
+                    dataByTopic.length === 1 ? `url(#${lineGradientId})` : getLineColor(d)
+                ))
+            );
 
             lines
                 .exit()

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -231,6 +231,16 @@ define([
 
                         expect(actual).toEqual(expected);
                     });
+
+                    it('should not throw error on mousemove', function() {
+                        let container = containerFixture.selectAll('svg'),
+                            newDataset = buildDataSet('withOneSource');
+
+                        // Need to refresh the data twice to get failure before fix
+                        containerFixture.datum(newDataset).call(lineChart);
+                        containerFixture.datum(newDataset).call(lineChart);
+                        container.dispatch('mousemove');
+                    })
                 });
             });
 


### PR DESCRIPTION
Bug on data refresh, see #541.

## Description
Wrapped setting of paths property in line chart with lines.merge() to ensure the property contains both the enter and the update selection.

## Motivation and Context
Resolves #541.

## How Has This Been Tested?
- Added new test to line.spec.js that will throw an error with out the fix
- re-ran tests

## Types of changes
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
