### PR TITLE
Fix - ability to override the margins without impacting render

### DIFF
--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -932,7 +932,10 @@ define(function(require) {
             if (!arguments.length) {
                 return margin;
             }
-            margin = _x;
+            margin = {
+                ...margin,
+                ..._x
+            };
 
             return this;
         };

--- a/src/charts/brush.js
+++ b/src/charts/brush.js
@@ -525,7 +525,10 @@ define(function(require) {
             if (!arguments.length) {
                 return margin;
             }
-            margin = _x;
+            margin = {
+                ...margin,
+                ..._x
+            };
 
             return this;
         };

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -740,7 +740,10 @@ define(function(require) {
             if (!arguments.length) {
                 return margin;
             }
-            margin = _x;
+            margin = {
+                ...margin,
+                ..._x
+            };
 
             return this;
         };

--- a/src/charts/grouped-bar.js
+++ b/src/charts/grouped-bar.js
@@ -961,7 +961,10 @@ define(function (require) {
             if (!arguments.length) {
                 return margin;
             }
-            margin = _x;
+            margin = {
+                ...margin,
+                ..._x
+            };
 
             return this;
         };

--- a/src/charts/legend.js
+++ b/src/charts/legend.js
@@ -489,7 +489,10 @@ define(function(require){
             if (!arguments.length) {
                 return margin;
             }
-            margin = _x;
+            margin = {
+                ...margin,
+                ..._x
+            };
 
             return this;
         };

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -1182,7 +1182,10 @@ define(function(require){
             if (!arguments.length) {
                 return margin;
             }
-            margin = _x;
+            margin = {
+                ...margin,
+                ..._x
+            };
 
             return this;
         };

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -496,7 +496,10 @@ define(function(require){
             if (!arguments.length) {
                 return margin;
             }
-            margin = _x;
+            margin = {
+                ...margin,
+                ..._x
+            };
 
             return this;
         };

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -1250,7 +1250,10 @@ define(function(require){
             if (!arguments.length) {
                 return margin;
             }
-            margin = _x;
+            margin = {
+                ...margin,
+                ..._x
+            };
 
             return this;
         };

--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -977,7 +977,10 @@ define(function(require){
             if (!arguments.length) {
                 return margin;
             }
-            margin = _x;
+            margin = {
+                ...margin,
+                ..._x
+            };
 
             return this;
         };

--- a/src/charts/step.js
+++ b/src/charts/step.js
@@ -398,7 +398,10 @@ define(function(require) {
             if (!arguments.length) {
                 return margin;
             }
-            margin = _x;
+            margin = {
+                ...margin,
+                ..._x
+            };
             return this;
         };
 

--- a/test/specs/bar.spec.js
+++ b/test/specs/bar.spec.js
@@ -325,7 +325,7 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
                 actual = barChart.margin();
 
                 expect(previous).not.toBe(actual);
-                expect(actual).toBe(expected);
+                expect(actual).toEqual(expected);
             });
 
             it('should provide loadingState getter and setter', () => {
@@ -483,6 +483,25 @@ define(['d3', 'bar', 'barChartDataBuilder'], function(d3, chart, dataBuilder) {
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);
             });
+        });
+
+        describe('when margins are set partially', function() {
+            
+            it('should override the default values', () => {
+                let previous = barChart.margin(),
+                expected = {
+                    ...previous,
+                    top: 10,
+                    right: 20
+                },
+                actual;
+
+                barChart.width(expected);
+                actual = barChart.width();
+
+                expect(previous).not.toBe(actual);
+                expect(actual).toEqual(expected);
+            })
         });
 
         describe('when clicking on a bar', function() {

--- a/test/specs/brush.spec.js
+++ b/test/specs/brush.spec.js
@@ -57,6 +57,25 @@ define(['jquery', 'd3', 'brush', 'brushChartDataBuilder'], function($, d3, chart
             expect(containerFixture.selectAll('.handle.handle--w.brush-rect').empty()).toEqual(false);
         });
 
+        describe('when margins are set partially', function() {
+            
+            it('should override the default values', () => {
+                let previous = brushChart.margin(),
+                expected = {
+                    ...previous,
+                    top: 10,
+                    right: 20
+                },
+                actual;
+
+                brushChart.width(expected);
+                actual = brushChart.width();
+
+                expect(previous).not.toBe(actual);
+                expect(actual).toEqual(expected);
+            })
+        });  
+
         describe('the API', function() {
 
             it('should provide a bush date range getter and setter', () => {
@@ -116,7 +135,7 @@ define(['jquery', 'd3', 'brush', 'brushChartDataBuilder'], function($, d3, chart
                 actual = brushChart.margin();
 
                 expect(previous).not.toBe(expected);
-                expect(actual).toBe(expected);
+                expect(actual).toEqual(expected);
             });
 
             it('should provide width getter and setter', function() {

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -347,7 +347,7 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                     actual = donutChart.margin();
 
                     expect(previous).not.toBe(expected);
-                    expect(actual).toBe(expected);
+                    expect(actual).toEqual(expected);
                 });
 
                 it('should provide externalRadius getter and setter', () => {
@@ -504,6 +504,25 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                     expect(previous).not.toBe(expected);
                     expect(actual).toBe(expected);
                 });
+            });
+
+            describe('when margins are set partially', function() {
+            
+                it('should override the default values', () => {
+                    let previous = donutChart.margin(),
+                    expected = {
+                        ...previous,
+                        top: 10,
+                        right: 20
+                    },
+                    actual;
+    
+                    donutChart.width(expected);
+                    actual = donutChart.width();
+    
+                    expect(previous).not.toBe(actual);
+                    expect(actual).toEqual(expected);
+                })
             });
 
             describe('when mouse events are triggered', () => {

--- a/test/specs/grouped-bar.spec.js
+++ b/test/specs/grouped-bar.spec.js
@@ -230,7 +230,7 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
                 actual = groupedBarChart.margin();
 
                 expect(previous).not.toBe(actual);
-                expect(actual).toBe(expected);
+                expect(actual).toEqual(expected);
             });
 
             it('should provide nameLabel getter and setter', () => {
@@ -357,6 +357,25 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
                 expect(newYAxisLabelOffset).toBe(testYAxisLabelOffset);
             });
         });
+
+        describe('when margins are set partially', function() {
+            
+            it('should override the default values', () => {
+                let previous = groupedBarChart.margin(),
+                expected = {
+                    ...previous,
+                    top: 10,
+                    right: 20
+                },
+                actual;
+
+                groupedBarChart.width(expected);
+                actual = groupedBarChart.width();
+
+                expect(previous).not.toBe(actual);
+                expect(actual).toEqual(expected);
+            })
+        });  
 
         describe('when clicking on a bar', () => {
 

--- a/test/specs/legend.spec.js
+++ b/test/specs/legend.spec.js
@@ -123,7 +123,7 @@ define(['d3', 'legend', 'donutChartDataBuilder'], function(d3, legend, dataBuild
                     actual = legendChart.margin();
 
                     expect(previous).not.toBe(expected);
-                    expect(actual).toBe(expected);
+                    expect(actual).toEqual(expected);
                 });
 
                 it('should provide margin ratio getter and setter', () =>{
@@ -266,6 +266,25 @@ define(['d3', 'legend', 'donutChartDataBuilder'], function(d3, legend, dataBuild
                 });
             });
         });
+
+        describe('when margins are set partially', function() {
+            
+            it('should override the default values', () => {
+                let previous = legendChart.margin(),
+                expected = {
+                    ...previous,
+                    top: 10,
+                    right: 20
+                },
+                actual;
+
+                legendChart.width(expected);
+                actual = legendChart.width();
+
+                expect(previous).not.toBe(actual);
+                expect(actual).toEqual(expected);
+            })
+        });  
 
         describe('when legend is horizontal', () => {
 

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -303,7 +303,7 @@ define([
                     actual = lineChart.margin();
 
                     expect(previous).not.toBe(expected);
-                    expect(actual).toBe(expected);
+                    expect(actual).toEqual(expected);
                 });
 
                 it('should provide width getter and setter', () => {
@@ -609,6 +609,25 @@ define([
                     });
                 });
             });
+
+            describe('when margins are set partially', function() {
+            
+                it('should override the default values', () => {
+                    let previous = lineChart.margin(),
+                    expected = {
+                        ...previous,
+                        top: 10,
+                        right: 20
+                    },
+                    actual;
+    
+                    lineChart.width(expected);
+                    actual = lineChart.width();
+    
+                    expect(previous).not.toBe(actual);
+                    expect(actual).toEqual(expected);
+                })
+            });            
 
             describe('Export chart functionality', () => {
 

--- a/test/specs/sparkline.spec.js
+++ b/test/specs/sparkline.spec.js
@@ -195,7 +195,7 @@ define([
                 newMargin = sparklineChart.margin();
 
                 expect(defaultMargin).not.toBe(testMargin);
-                expect(newMargin).toBe(testMargin);
+                expect(newMargin).toEqual(testMargin);
             });
 
             it('should provide loadingState getter and setter', () => {
@@ -336,6 +336,25 @@ define([
                 expect(newTitleTextStyle).toEqual(testTitleTextStyle);
             });
         });
+
+        describe('when margins are set partially', function() {
+            
+            it('should override the default values', () => {
+                let previous = sparklineChart.margin(),
+                expected = {
+                    ...previous,
+                    top: 10,
+                    right: 20
+                },
+                actual;
+
+                sparklineChart.width(expected);
+                actual = sparklineChart.width();
+
+                expect(previous).not.toBe(actual);
+                expect(actual).toEqual(expected);
+            })
+        });   
 
         describe('Export chart functionality', () => {
 

--- a/test/specs/stacked-area.spec.js
+++ b/test/specs/stacked-area.spec.js
@@ -384,7 +384,7 @@ define([
                 actual = stackedAreaChart.margin();
 
                 expect(previous).not.toBe(expected);
-                expect(actual).toBe(expected);
+                expect(actual).toEqual(expected);
             });
 
             it('should provide a tooltip threshold getter and setter', () => {
@@ -518,6 +518,25 @@ define([
                 expect(defaultYAxisLabelOffset).not.toBe(newYAxisLabelOffset);
                 expect(newYAxisLabelOffset).toBe(testYAxisLabelOffset);
             });
+        });
+
+        describe('when margins are set partially', function() {
+            
+            it('should override the default values', () => {
+                let previous = stackedAreaChart.margin(),
+                expected = {
+                    ...previous,
+                    top: 10,
+                    right: 20
+                },
+                actual;
+
+                stackedAreaChart.width(expected);
+                actual = stackedAreaChart.width();
+
+                expect(previous).not.toBe(actual);
+                expect(actual).toEqual(expected);
+            })
         });
 
         describe('Aspect Ratio', function() {

--- a/test/specs/stacked-bar.spec.js
+++ b/test/specs/stacked-bar.spec.js
@@ -255,7 +255,7 @@ define(['d3', 'stacked-bar', 'stackedBarDataBuilder'], function(d3, chart, dataB
                 actual = stackedBarChart.margin();
 
                 expect(previous).not.toBe(actual);
-                expect(actual).toBe(expected);
+                expect(actual).toEqual(expected);
             });
 
             it('should provide nameLabel getter and setter', () => {
@@ -404,6 +404,25 @@ define(['d3', 'stacked-bar', 'stackedBarDataBuilder'], function(d3, chart, dataB
                 expect(callbackSpy.calls.allArgs()[0].length).toBe(2);
             })
         });
+
+        describe('when margins are set partially', function() {
+            
+            it('should override the default values', () => {
+                let previous = stackedBarChart.margin(),
+                expected = {
+                    ...previous,
+                    top: 10,
+                    right: 20
+                },
+                actual;
+
+                stackedBarChart.width(expected);
+                actual = stackedBarChart.width();
+
+                expect(previous).not.toBe(actual);
+                expect(actual).toEqual(expected);
+            })
+        });  
 
         describe('when hovering', function() {
 

--- a/test/specs/step.spec.js
+++ b/test/specs/step.spec.js
@@ -109,7 +109,7 @@ define([
                 newMargin = stepChart.margin();
 
                 expect(defaultMargin).not.toBe(newMargin);
-                expect(newMargin).toBe(testMargin);
+                expect(newMargin).toEqual(testMargin);
             });
 
             it('should provide height getter and setter', () => {
@@ -208,6 +208,25 @@ define([
                 expect(newXAxisLabelOffset).toBe(testXAxisLabelOffset);
             });
         });
+
+        describe('when margins are set partially', function() {
+            
+            it('should override the default values', () => {
+                let previous = stepChart.margin(),
+                expected = {
+                    ...previous,
+                    top: 10,
+                    right: 20
+                },
+                actual;
+
+                stepChart.width(expected);
+                actual = stepChart.width();
+
+                expect(previous).not.toBe(actual);
+                expect(actual).toEqual(expected);
+            })
+        });   
 
         describe('when hovering a step', function() {
 


### PR DESCRIPTION
Margins can be set partially without impacting charts.

## Description
Instead of assigning a value use spread operator to override the default margins and prevent charts from breaking.

```
chart.margin({
   top: 10,
   bottom: 20
})
```

## Motivation and Context
https://github.com/eventbrite/britecharts/issues/556

## How Has This Been Tested?
* Revised margin setter/getter tests to use `toEqual` instead
* Added a new test for each chart to check if the margins can be overriden

## Screenshots (if appropriate):
Looks same, except it applies default margins if not set.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
