### PR TITLE
Feature - ability to set hollow circle area

### DIFF
--- a/demos/css/britecharts.css
+++ b/demos/css/britecharts.css
@@ -120,6 +120,9 @@
 .scatter-plot .x.axis path {
   display: none; }
 
+.scatter-plot .data-point-highlighter {
+  stroke-width: 1.2; }
+
 .sparkline {
   stroke: #ADB0B6;
   stroke-width: 1;

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -22,7 +22,8 @@ function createSimpleScatterPlot() {
 
         scatter
             .width(750)
-            .maxCircleArea(15);
+            .maxCircleArea(15)
+            .hasHollowCircles(true);
 
         scatterPlotContainer.datum(dataset).call(scatter);
     }

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -22,8 +22,7 @@ function createSimpleScatterPlot() {
 
         scatter
             .width(750)
-            .maxCircleArea(15)
-            .hasHollowCircles(true);
+            .maxCircleArea(15);
 
         scatterPlotContainer.datum(dataset).call(scatter);
     }

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -525,6 +525,12 @@ define(function(require) {
             return this;
         }
 
+        /**
+         * Gets or Sets the maximum value of the chart area
+         * @param  {boolean} _x=false             Choose whether chart's data points/circles should be hollow
+         * @return {hasHollowCircles | module}    Current hasHollowCircles value or Scatter Chart module to chain calls
+         * @public
+         */
         exports.hasHollowCircles = function(_x) {
             if (!arguments.length) {
                 return hasHollowCircles;

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -122,6 +122,8 @@ define(function(require) {
         delay = 500,
         duration = 500,
 
+        hasHollowCircles = false,
+
         svg,
         chartWidth,
         chartHeight,
@@ -387,10 +389,16 @@ define(function(require) {
                     .duration(duration)
                     .ease(ease)
                     .attr('class', 'point')
+                    .attr('class', 'data-point-highlighter')
+                    .style('stroke', (d) => (
+                        hasHollowCircles ? nameColorMap[d.name] : null
+                    ))
                     .attr('r', (d) => areaScale(d.y))
                     .attr('cx', (d) => xScale(d.x))
                     .attr('cy', (d) => yScale(d.y))
-                    .attr('fill', (d) => nameColorMap[d.name])
+                    .attr('fill', (d) => (
+                        hasHollowCircles ? '#fff' : nameColorMap[d.name]
+                    ))
                     .style('cursor', 'pointer');
             } else {
                 circles
@@ -399,10 +407,16 @@ define(function(require) {
                           handleClick(this, d, chartWidth, chartHeight);
                       })
                       .attr('class', 'point')
+                      .attr('class', 'data-point-highlighter')
+                      .style('stroke', (d) => (
+                          hasHollowCircles ? nameColorMap[d.name] : null
+                      ))
                       .attr('r', (d) => areaScale(d.y))
                       .attr('cx', (d) => xScale(d.x))
                       .attr('cy', (d) => yScale(d.y))
-                      .attr('fill', (d) => nameColorMap[d.name])
+                      .attr('fill', (d) => (
+                          hasHollowCircles ? '#fff' : nameColorMap[d.name]
+                      ))
                       .style('cursor', 'pointer');
             }
         }
@@ -507,6 +521,15 @@ define(function(require) {
                 return maxCircleArea;
             }
             maxCircleArea = _x;
+
+            return this;
+        }
+
+        exports.hasHollowCircles = function(_x) {
+            if (!arguments.length) {
+                return hasHollowCircles;
+            }
+            hasHollowCircles = _x;
 
             return this;
         }

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -478,6 +478,21 @@ define(function(require) {
         };
 
         /**
+         * Gets or Sets the hasHollowCircles value of the chart area
+         * @param  {boolean} _x=false             Choose whether chart's data points/circles should be hollow
+         * @return {hasHollowCircles | module}    Current hasHollowCircles value or Scatter Chart module to chain calls
+         * @public
+         */
+        exports.hasHollowCircles = function (_x) {
+            if (!arguments.length) {
+                return hasHollowCircles;
+            }
+            hasHollowCircles = _x;
+
+            return this;
+        }
+
+        /**
          * Gets or Sets isAnimated value. If set to true,
          * the chart will be initialized or updated with animation.
          * @param  {boolean} _x=false       Desired margin object properties for each side
@@ -522,21 +537,6 @@ define(function(require) {
                 return maxCircleArea;
             }
             maxCircleArea = _x;
-
-            return this;
-        }
-
-        /**
-         * Gets or Sets the maximum value of the chart area
-         * @param  {boolean} _x=false             Choose whether chart's data points/circles should be hollow
-         * @return {hasHollowCircles | module}    Current hasHollowCircles value or Scatter Chart module to chain calls
-         * @public
-         */
-        exports.hasHollowCircles = function(_x) {
-            if (!arguments.length) {
-                return hasHollowCircles;
-            }
-            hasHollowCircles = _x;
 
             return this;
         }

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -94,6 +94,7 @@ define(function(require) {
         xTicks = 6,
         yTicks = null,
         tickPadding = 5,
+        hollowColor = '#fff',
 
         grid = null,
         baseLine,
@@ -397,7 +398,7 @@ define(function(require) {
                     .attr('cx', (d) => xScale(d.x))
                     .attr('cy', (d) => yScale(d.y))
                     .attr('fill', (d) => (
-                        hasHollowCircles ? '#fff' : nameColorMap[d.name]
+                        hasHollowCircles ? hollowColor : nameColorMap[d.name]
                     ))
                     .style('cursor', 'pointer');
             } else {
@@ -415,7 +416,7 @@ define(function(require) {
                       .attr('cx', (d) => xScale(d.x))
                       .attr('cy', (d) => yScale(d.y))
                       .attr('fill', (d) => (
-                          hasHollowCircles ? '#fff' : nameColorMap[d.name]
+                          hasHollowCircles ? hollowColor : nameColorMap[d.name]
                       ))
                       .style('cursor', 'pointer');
             }

--- a/src/styles/charts/scatter-plot.scss
+++ b/src/styles/charts/scatter-plot.scss
@@ -1,4 +1,6 @@
 
+$outline-stroke-width: 1.2;
+
 .scatter-plot {
     // Axes
     .y-axis-group {
@@ -16,5 +18,9 @@
 
     .x.axis path {
         display: none;
+    }
+
+    .data-point-highlighter {
+        stroke-width: $outline-stroke-width;
     }
 }

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -92,7 +92,7 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
                 expect(actual).toBe(expected);
             });
 
-            it('should provide maxCircleArea getter and setter', () => {
+            it('should provide hasHollowCircles getter and setter', () => {
                 let previous = scatterPlot.hasHollowCircles(),
                     expected = true,
                     actual;

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -92,6 +92,18 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
                 expect(actual).toBe(expected);
             });
 
+            it('should provide maxCircleArea getter and setter', () => {
+                let previous = scatterPlot.hasHollowCircles(),
+                    expected = true,
+                    actual;
+
+                scatterPlot.hasHollowCircles(expected);
+                actual = scatterPlot.hasHollowCircles();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toEqual(expected);
+            });
+
             it('should provide height getter and setter', () => {
                 let previous = scatterPlot.width(),
                     expected = 200,


### PR DESCRIPTION
Added a function that sets the look of circles as hollow circles.

## Description
Added a function that allows user to display data points with "hollow circles" where:
* fill = `#fff`
* stroke-color - `nameColorMap[d.name]`
I used the same stroke-width used for stacked area and line.

## Motivation and Context
Hollow circles look neat

## How Has This Been Tested?
Added a setter/getter test that checks the expected value of the function output.

## Screenshots (if appropriate):
Before:
![screen shot 2018-03-21 at 9 52 58 pm](https://user-images.githubusercontent.com/31934144/37751886-3df3b514-2d52-11e8-8c28-0ebb4710fb72.png)

After:
![screen shot 2018-03-21 at 9 55 49 pm](https://user-images.githubusercontent.com/31934144/37751974-b7c7fb02-2d52-11e8-9f5c-888fa1765e0d.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
