### PR TITLE
Feature - ability to highlight data points with function in Line chart

### DIFF
--- a/demos/css/britecharts.css
+++ b/demos/css/britecharts.css
@@ -95,6 +95,9 @@
 .bar-chart .percentage-label {
   fill: #666A73; }
 
+.line-chart .data-point-marks {
+  fill: #ffffff; }
+
 .line-chart .topic .line {
   fill: none;
   stroke-width: 2;

--- a/demos/css/britecharts.css
+++ b/demos/css/britecharts.css
@@ -95,7 +95,7 @@
 .bar-chart .percentage-label {
   fill: #666A73; }
 
-.line-chart .data-point-marks {
+.line-chart .data-point-mark {
   fill: #ffffff; }
 
 .line-chart .topic .line {

--- a/demos/demo-line.js
+++ b/demos/demo-line.js
@@ -70,7 +70,6 @@ function createLineChart(optionalColorSchema, optionalData) {
             .grid('horizontal')
             .tooltipThreshold(600)
             .width(containerWidth)
-            .shouldShowAllDataPoints(true)
             .margin(lineMargin)
             .dateLabel('fullDate')
             .on('customMouseOver', chartTooltip.show)

--- a/demos/demo-line.js
+++ b/demos/demo-line.js
@@ -70,6 +70,7 @@ function createLineChart(optionalColorSchema, optionalData) {
             .grid('horizontal')
             .tooltipThreshold(600)
             .width(containerWidth)
+            .shouldShowAllDataPoints(true)
             .margin(lineMargin)
             .dateLabel('fullDate')
             .on('customMouseOver', chartTooltip.show)

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -734,6 +734,10 @@ define(function(require){
          * @return void
          */
         function drawAllDataPoints() {
+            svg.select('.chart-group')
+                .selectAll('.data-points-container')
+                .remove();
+
             const nodes = paths.nodes()
             const nodesById = nodes.reduce((acc, node) => {
                 acc[node.id] = node
@@ -742,7 +746,7 @@ define(function(require){
             }, {});
 
 
-            let allTopics = dataByDate.reduce((accum, dataPoint) => {
+            const allTopics = dataByDate.reduce((accum, dataPoint) => {
                 const dataPointTopics = dataPoint.topics.map(topic => ({
                     topic,
                     node: nodesById[topic.name]
@@ -754,6 +758,8 @@ define(function(require){
             }, []);
 
             let allDataPoints = svg.select('.chart-group')
+                .append('g')
+                .classed('data-points-container', true)
                 .selectAll('circle')
                 .data(allTopics)
                 .enter()

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -249,7 +249,6 @@ define(function(require){
                     addMouseEvents();
                 }
 
-                shouldShowAllDataPoints = true;
                 if (shouldShowAllDataPoints) {
                     drawAllDataPoints();
                 }
@@ -728,6 +727,12 @@ define(function(require){
             }
         }
 
+        /**
+         * Draws all data points of the chart
+         * if shouldShowAllDataPoints is set to true
+         * @inner
+         * @return void
+         */
         function drawAllDataPoints() {
             const nodes = paths.nodes()
             const nodesById = nodes.reduce((acc, node) => {
@@ -759,8 +764,8 @@ define(function(require){
                   .style('stroke', (d) => topicColorMap[d.topic.name])
                   .style('cursor', 'pointer')
                   .attr('cx', d => xScale(new Date(d.topic.date)))
-                  .attr('cy', d => getPathYFromX(xScale(new Date(d.topic.date)), d.node, d.name));            
-        }
+                  .attr('cy', d => getPathYFromX(xScale(new Date(d.topic.date)), d.node, d.topic.name));
+                }
 
         /**
          * Creates the vertical marker

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -738,7 +738,7 @@ define(function(require){
                 .selectAll('.data-points-container')
                 .remove();
 
-            const nodesById = paths.nodes().nodes.reduce((acc, node) => {
+            const nodesById = paths.nodes().reduce((acc, node) => {
                 acc[node.id] = node
 
                 return acc;

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -759,15 +759,7 @@ define(function(require){
                   .style('stroke', (d) => topicColorMap[d.topic.name])
                   .style('cursor', 'pointer')
                   .attr('cx', d => xScale(new Date(d.topic.date)))
-                  .attr('cy', d => getPathYFromX(xScale(new Date(d.topic.date)), d.node, d.name));
-            
-
-            
-                // const path = topicsWithNode[index].node;
-                // const x = xScale(new Date(dataPoint.topics[index].date));
-                // const y = getPathYFromX(x, path, d.name);
-
-                // allDataPoints.attr('transform', `translate( ${x}, ${y} )` );
+                  .attr('cy', d => getPathYFromX(xScale(new Date(d.topic.date)), d.node, d.name));            
         }
 
         /**

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -730,7 +730,7 @@ define(function(require){
         /**
          * Draws all data points of the chart
          * if shouldShowAllDataPoints is set to true
-         * @inner
+         * @private
          * @return void
          */
         function drawAllDataPoints() {
@@ -758,19 +758,19 @@ define(function(require){
             }, []);
 
             let allDataPoints = svg.select('.chart-group')
-                .append('g')
-                .classed('data-points-container', true)
-                .selectAll('circle')
-                .data(allTopics)
-                .enter()
-                  .append('circle')
-                  .classed('data-point-marks', true)
-                  .attr('r', highlightCircleRadius)
-                  .style('stroke-width', highlightCircleStroke)
-                  .style('stroke', (d) => topicColorMap[d.topic.name])
-                  .style('cursor', 'pointer')
-                  .attr('cx', d => xScale(new Date(d.topic.date)))
-                  .attr('cy', d => getPathYFromX(xScale(new Date(d.topic.date)), d.node, d.topic.name));
+              .append('g')
+              .classed('data-points-container', true)
+              .selectAll('circle')
+              .data(allTopics)
+              .enter()
+                .append('circle')
+                .classed('data-point-mark', true)
+                .attr('r', highlightCircleRadius)
+                .style('stroke-width', highlightCircleStroke)
+                .style('stroke', (d) => topicColorMap[d.topic.name])
+                .style('cursor', 'pointer')
+                .attr('cx', d => xScale(new Date(d.topic.date)))
+                .attr('cy', d => getPathYFromX(xScale(new Date(d.topic.date)), d.node, d.topic.name));
         }
 
         /**
@@ -906,8 +906,7 @@ define(function(require){
         function highlightDataPoints(dataPoint) {
             cleanDataPointHighlights();
 
-            const nodes = paths.nodes()
-            const nodesById = nodes.reduce((acc, node) => {
+            const nodesById = paths.nodes().reduce((acc, node) => {
                 acc[node.id] = node
 
                 return acc;

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -906,7 +906,7 @@ define(function(require){
             cleanDataPointHighlights();
 
             const nodes = paths.nodes()
-            const nodesById = paths.nodes().reduce((acc, node) => {
+            const nodesById = nodes.reduce((acc, node) => {
                 acc[node.id] = node
 
                 return acc;

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -765,7 +765,7 @@ define(function(require){
                   .style('cursor', 'pointer')
                   .attr('cx', d => xScale(new Date(d.topic.date)))
                   .attr('cy', d => getPathYFromX(xScale(new Date(d.topic.date)), d.node, d.topic.name));
-                }
+        }
 
         /**
          * Creates the vertical marker
@@ -1281,6 +1281,21 @@ define(function(require){
 
             return this;
         };
+
+        /**
+         * Gets or Sets the topicLabel of the chart
+         * @param  {Boolean} _x=false       Whether all data points should be drawn
+         * @return {shouldShowAllDataPoints | module}   Current shouldShowAllDataPoints or Chart module to chain calls
+         * @public
+         */
+        exports.shouldShowAllDataPoints = function(_x) {
+            if (!arguments.length) {
+                return shouldShowAllDataPoints;
+            }
+            shouldShowAllDataPoints = _x;
+
+            return this;
+        }
 
         /**
          * Gets or Sets the minimum width of the graph in order to show the tooltip

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -738,8 +738,7 @@ define(function(require){
                 .selectAll('.data-points-container')
                 .remove();
 
-            const nodes = paths.nodes()
-            const nodesById = nodes.reduce((acc, node) => {
+            const nodesById = paths.nodes().nodes.reduce((acc, node) => {
                 acc[node.id] = node
 
                 return acc;
@@ -906,6 +905,7 @@ define(function(require){
         function highlightDataPoints(dataPoint) {
             cleanDataPointHighlights();
 
+            const nodes = paths.nodes()
             const nodesById = paths.nodes().reduce((acc, node) => {
                 acc[node.id] = node
 

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -748,45 +748,18 @@ define(function(require){
                 return accum;
             }, []);
 
-            // dataPoint.topics.forEach((d, index) => {
-            //     let marker = verticalMarkerContainer
-            //                   .append('g')
-            //                     .classed('circle-container', true)
-            //                       .append('circle')
-            //                         .classed('data-point-highlighter', true)
-            //                         .attr('cx', highlightCircleSize)
-            //                         .attr('cy', 0)
-            //                         .attr('r', highlightCircleRadius)
-            //                         .style('stroke-width', highlightCircleStroke)
-            //                         .style('stroke', topicColorMap[d.name])
-            //                         .style('cursor', 'pointer')
-            //                         .on('click', function () {
-            //                             addGlowFilter(this);
-            //                             handleHighlightClick(this, d);
-            //                         })
-            //                         .on('mouseout', function () {
-            //                             removeFilter(this);
-            //                         });
-
             let allDataPoints = svg.select('.chart-group')
                 .selectAll('circle')
                 .data(allTopics)
                 .enter()
                   .append('circle')
-                  .classed('data-point-highlighter', true)
-                  .attr('cx', highlightCircleSize)
-                  .attr('cy', 0)
+                  .classed('data-point-marks', true)
                   .attr('r', highlightCircleRadius)
                   .style('stroke-width', highlightCircleStroke)
-                  .style('stroke', d => topicColorMap[d.name])
+                  .style('stroke', (d) => topicColorMap[d.topic.name])
                   .style('cursor', 'pointer')
-                  .attr('transform', (d, index) => {
-                      const path = d.node;
-                      const x = xScale(new Date(d.topic.date));
-                      const y = getPathYFromX(x, path, d.name);
-
-                      return `translate(${x}, ${y})`;
-                  });
+                  .attr('cx', d => xScale(new Date(d.topic.date)))
+                  .attr('cy', d => getPathYFromX(xScale(new Date(d.topic.date)), d.node, d.name));
             
 
             

--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -164,6 +164,7 @@ define(function(require){
             xAxisCustomFormat = null,
             locale,
 
+            shouldShowAllDataPoints = false,
             isAnimated = false,
             ease = d3Ease.easeQuadInOut,
             animationDuration = 1500,
@@ -246,6 +247,11 @@ define(function(require){
                     drawHoverOverlay();
                     drawVerticalMarker();
                     addMouseEvents();
+                }
+
+                shouldShowAllDataPoints = true;
+                if (shouldShowAllDataPoints) {
+                    drawAllDataPoints();
                 }
 
                 addTouchEvents();
@@ -720,6 +726,75 @@ define(function(require){
                     .attr('fill', overlayColor)
                     .style('display', 'none');
             }
+        }
+
+        function drawAllDataPoints() {
+            const nodes = paths.nodes()
+            const nodesById = nodes.reduce((acc, node) => {
+                acc[node.id] = node
+
+                return acc;
+            }, {});
+
+
+            let allTopics = dataByDate.reduce((accum, dataPoint) => {
+                const dataPointTopics = dataPoint.topics.map(topic => ({
+                    topic,
+                    node: nodesById[topic.name]
+                }));
+
+                accum = [...accum, ...dataPointTopics];
+
+                return accum;
+            }, []);
+
+            // dataPoint.topics.forEach((d, index) => {
+            //     let marker = verticalMarkerContainer
+            //                   .append('g')
+            //                     .classed('circle-container', true)
+            //                       .append('circle')
+            //                         .classed('data-point-highlighter', true)
+            //                         .attr('cx', highlightCircleSize)
+            //                         .attr('cy', 0)
+            //                         .attr('r', highlightCircleRadius)
+            //                         .style('stroke-width', highlightCircleStroke)
+            //                         .style('stroke', topicColorMap[d.name])
+            //                         .style('cursor', 'pointer')
+            //                         .on('click', function () {
+            //                             addGlowFilter(this);
+            //                             handleHighlightClick(this, d);
+            //                         })
+            //                         .on('mouseout', function () {
+            //                             removeFilter(this);
+            //                         });
+
+            let allDataPoints = svg.select('.chart-group')
+                .selectAll('circle')
+                .data(allTopics)
+                .enter()
+                  .append('circle')
+                  .classed('data-point-highlighter', true)
+                  .attr('cx', highlightCircleSize)
+                  .attr('cy', 0)
+                  .attr('r', highlightCircleRadius)
+                  .style('stroke-width', highlightCircleStroke)
+                  .style('stroke', d => topicColorMap[d.name])
+                  .style('cursor', 'pointer')
+                  .attr('transform', (d, index) => {
+                      const path = d.node;
+                      const x = xScale(new Date(d.topic.date));
+                      const y = getPathYFromX(x, path, d.name);
+
+                      return `translate(${x}, ${y})`;
+                  });
+            
+
+            
+                // const path = topicsWithNode[index].node;
+                // const x = xScale(new Date(dataPoint.topics[index].date));
+                // const y = getPathYFromX(x, path, d.name);
+
+                // allDataPoints.attr('transform', `translate( ${x}, ${y} )` );
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -250,7 +250,8 @@ define(function(require) {
         }
 
         /**
-         * Draws the grid lines for an horizontal bar chart
+         * Draw horizontal gridles of the chart
+         * These gridlines are parallel to x-axis
          * @return {void}
          */
         function drawHorizontalGridLines() {
@@ -267,8 +268,8 @@ define(function(require) {
         }
 
         /**
-         * Draws vertical gridlines of the chart.
-         * These gridlines are parallel to x-axis.
+         * Draws vertical gridlines of the chart
+         * These gridlines are parallel to y-axis
          * @return {void}
          */
         function drawVerticalGridLines() {
@@ -314,7 +315,7 @@ define(function(require) {
             const colorRange = colorScale.range();
 
             /**
-             * Maps data point category name to 
+             * Maps data point category name to
              * each color of the given color scheme
              * {
              *     name1: 'color1',
@@ -370,7 +371,7 @@ define(function(require) {
 
         /**
          * Draws the points for each data element
-         * on the charg group
+         * on the chart group
          * @private
         */
         function drawDataPoints() {

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -282,8 +282,6 @@ define(function(require) {
                 .attr('y2', chartHeight)
                 .attr('x1', (d) => xScale(d))
                 .attr('x2', (d) => xScale(d));
-
-            drawHorizontalExtendedLine();
         }
 
         /**
@@ -324,6 +322,7 @@ define(function(require) {
              *     name3: 'color3',
              *     ...
              * }
+             * @private
              */
             nameColorMap = colorScale.domain().reduce((accum, item, i) => {
                 accum[item] = colorRange[i];

--- a/src/styles/charts/line.scss
+++ b/src/styles/charts/line.scss
@@ -5,7 +5,7 @@ $line-width: 2;
 .line-chart {
 
     // Class for data point markers
-    .data-point-marks {
+    .data-point-mark {
         fill: $white;
     }
 

--- a/src/styles/charts/line.scss
+++ b/src/styles/charts/line.scss
@@ -4,6 +4,11 @@ $line-width: 2;
 
 .line-chart {
 
+    // Class for data point markers
+    .data-point-marks {
+        fill: $white;
+    }
+
     // Lines
     .topic .line {
         fill: none;

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -674,7 +674,7 @@ define([
                                         .nodes();
 
                         circles.forEach((circle) => {
-                            expect(circle).toHaveAttr('class', 'data-point-marks');
+                            expect(circle).toHaveAttr('class', 'data-point-mark');
                             expect(circle).toHaveAttr('r', '5');
                             expect(circle).toHaveAttr('cx');
                             expect(circle).toHaveAttr('cy');

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -622,23 +622,67 @@ define([
                 });
             });
 
-            describe('when shouldShowAllDataPoints is true', function() {
 
-                it('should override the default values', () => {
-                    let previous = lineChart.margin(),
-                    expected = {
-                        ...previous,
-                        top: 10,
-                        right: 20
-                    },
-                    actual;
+            describe('Chart data points', () => {
 
-                    lineChart.width(expected);
-                    actual = lineChart.width();
+                beforeEach(() => {
+                    dataset = aTestDataSet().with5Topics().build();
 
-                    expect(previous).not.toBe(actual);
-                    expect(actual).toEqual(expected);
-                })
+                    // DOM Fixture Setup
+                    f = jasmine.getFixtures();
+                    f.fixturesPath = 'base/test/fixtures/';
+                    f.load('testContainer.html');
+                });
+
+                afterEach(() => {
+                    containerFixture.remove();
+                    f = jasmine.getFixtures();
+                    f.cleanUp();
+                    f.clearCache();
+                });
+
+                describe('when shouldShowAllDataPoints is true', function() {
+
+                    beforeEach(function() {
+                        lineChart = chart().shouldShowAllDataPoints(true);
+
+                        containerFixture = d3.select('.test-container').append('svg');
+                        containerFixture.datum(dataset).call(lineChart);
+                    });
+
+                    it('chart should render data points container', () => {
+                        let expected = 1;
+                        let actual = containerFixture.select('.data-points-container').nodes().length;
+
+                        expect(actual).toEqual(expected);
+                    });
+
+                    it('data points container renders a circle for each data point', () => {
+                        let expected = dataset.dataByDate.reduce((accum, dataPoint) => (
+                            accum + dataPoint.topics.length
+                        ), 0);
+                        let actual = containerFixture.select('.data-points-container')
+                                       .selectAll('circle')
+                                       .nodes().length;
+
+                        expect(actual).toEqual(expected);
+                    });
+
+                    it('each data circle has proper attributes', () => {
+                        let circles = containerFixture.select('.data-points-container')
+                                        .selectAll('circle')
+                                        .nodes();
+
+                        circles.forEach((circle) => {
+                            expect(circle).toHaveAttr('class', 'data-point-marks');
+                            expect(circle).toHaveAttr('r', '5');
+                            expect(circle).toHaveAttr('cx');
+                            expect(circle).toHaveAttr('cy');
+                            expect(circle).toHaveAttr('style');
+                        });
+
+                    });
+                });
             });
 
             describe('when margins are set partially', function() {
@@ -733,7 +777,7 @@ define([
 
             describe('Axis Labels', () => {
                 describe('when axis labels aren\'t set', () => {
-    
+
                     beforeEach(() => {
                         dataset = aTestDataSet().withOneSource().build();
                         lineChart = chart();
@@ -741,68 +785,68 @@ define([
                         f = jasmine.getFixtures();
                         f.fixturesPath = 'base/test/fixtures/';
                         f.load('testContainer.html');
-    
+
                         containerFixture = d3.select('.test-container');
                         containerFixture.datum(dataset).call(lineChart);
                     });
-    
+
                     afterEach(() => {
                         containerFixture.remove();
                         f = jasmine.getFixtures();
                         f.cleanUp();
                         f.clearCache();
                     });
-    
+
                     it('should not render the x-axis label', () => {
                         let expected = 0,
                             actual = containerFixture.selectAll('.x-axis-label')['_groups'][0].length;
-    
+
                         expect(actual).toEqual(expected);
                     });
-    
+
                     it('should not render any axisLabel', () => {
                         let expected = 0,
                             actual = containerFixture.selectAll('.y-axis-label')['_groups'][0].length;
-    
+
                         expect(actual).toEqual(expected);
                     });
                 });
-    
+
                 describe('when axis labels are set', () => {
-    
+
                     beforeEach(() => {
                         dataset = aTestDataSet().withOneSource().build();
                         lineChart = chart()
                                         .xAxisLabel('valueSetX')
                                         .yAxisLabel('valueSetY');
-    
+
                         // DOM Fixture Setup
                         f = jasmine.getFixtures();
                         f.fixturesPath = 'base/test/fixtures/';
                         f.load('testContainer.html');
-    
+
                         containerFixture = d3.select('.test-container');
                         containerFixture.datum(dataset).call(lineChart);
                     });
-    
+
                     afterEach(() => {
                         containerFixture.remove();
                         f = jasmine.getFixtures();
                         f.cleanUp();
                         f.clearCache();
                     });
-    
+
                     it('should render the x-axis label', () => {
                         let expected = 1,
                             actual = containerFixture.selectAll('.x-axis-label')['_groups'][0].length;
-    
+
                         expect(actual).toEqual(expected);
                     });
-    
+
                     it('should render any axisLabel', () => {
                         let expected = 1,
                             actual = containerFixture.selectAll('.y-axis-label')['_groups'][0].length;
-    
+
                         expect(actual).toEqual(expected);
                     });
                 });

--- a/test/specs/line.spec.js
+++ b/test/specs/line.spec.js
@@ -578,6 +578,18 @@ define([
                     expect(previous).not.toBe(expected);
                     expect(actual).toBe(expected);
                 });
+
+                it ('should have shouldShowAllDataPoints getter and setter', () => {
+                    let previous = lineChart.shouldShowAllDataPoints(),
+                        expected = true,
+                        actual;
+
+                    lineChart.shouldShowAllDataPoints(expected);
+                    actual = lineChart.shouldShowAllDataPoints();
+
+                    expect(previous).not.toBe(expected);
+                    expect(actual).toBe(expected);
+                });
             });
 
             describe('Aspect Ratio', () => {
@@ -610,8 +622,8 @@ define([
                 });
             });
 
-            describe('when margins are set partially', function() {
-            
+            describe('when shouldShowAllDataPoints is true', function() {
+
                 it('should override the default values', () => {
                     let previous = lineChart.margin(),
                     expected = {
@@ -620,14 +632,33 @@ define([
                         right: 20
                     },
                     actual;
-    
+
                     lineChart.width(expected);
                     actual = lineChart.width();
-    
+
                     expect(previous).not.toBe(actual);
                     expect(actual).toEqual(expected);
                 })
-            });            
+            });
+
+            describe('when margins are set partially', function() {
+
+                it('should override the default values', () => {
+                    let previous = lineChart.margin(),
+                    expected = {
+                        ...previous,
+                        top: 10,
+                        right: 20
+                    },
+                    actual;
+
+                    lineChart.width(expected);
+                    actual = lineChart.width();
+
+                    expect(previous).not.toBe(actual);
+                    expect(actual).toEqual(expected);
+                })
+            });
 
             describe('Export chart functionality', () => {
 


### PR DESCRIPTION
Added ability to show all data points with new function `shouldShowAllDataPoints` in *Line* chart.

## Description
Added new Line chart API function `shouldShowAllDataPoints`. The data points highlight look exactly like the points rendered when user hovers over a specific data point range in Line.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/eventbrite/britecharts/issues/459

## How Has This Been Tested?
* Added setter/getter test
* Added DOM inspection test that checks if new container group for data points was created and that each data point circle have correct attributes.

## Screenshots (if appropriate):
![screen shot 2018-03-25 at 4 59 21 am](https://user-images.githubusercontent.com/9118852/37875416-b5deaf40-2ff3-11e8-8a34-4f08e06ab0e4.png)

![screen shot 2018-03-25 at 4 59 27 am](https://user-images.githubusercontent.com/9118852/37875414-b0f67468-2ff3-11e8-9b5f-7d4c2689e034.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
