### PR TITLE
Feature - ability to set y axis label and offset

### DIFF
--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -23,9 +23,13 @@ function createScatterPlotWithSingleSource() {
 
         scatter
             .width(750)
+            .margin({left: 50})
             .circleOpacity(0.6)
-            .grid('horizontal');
-            
+            .grid('horizontal')
+            .margin({
+                left: 60
+            })
+            .yAxisLabel('Ice Cream Sales');
 
         scatterPlotContainer.datum(dataset).call(scatter);
     }

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -23,7 +23,6 @@ function createScatterPlotWithSingleSource() {
 
         scatter
             .width(750)
-            .margin({left: 50})
             .circleOpacity(0.6)
             .grid('horizontal')
             .margin({

--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -12,9 +12,13 @@
                 <pre><code class="language-javascript">
 scatter
     .width(750)
+    .margin({left: 50})
     .circleOpacity(0.6)
-    .grid('horizontal');
-                        
+    .grid('horizontal')
+    .margin({
+        left: 60
+    })
+    .yAxisLabel('Ice Cream Sales');
 
 container.datum(dataset).call(lineChart);
                 </code></pre>

--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -12,7 +12,6 @@
                 <pre><code class="language-javascript">
 scatter
     .width(750)
-    .margin({left: 50})
     .circleOpacity(0.6)
     .grid('horizontal')
     .margin({

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -221,7 +221,7 @@ define(function(require) {
         }
 
         /**
-         * Draws axis labels across axis to
+         * Draws axis labels next to x and y axis to
          * represent data value label on the chart
          * @private
          */

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -222,7 +222,7 @@ define(function(require) {
 
         /**
          * Draws axis labels next to x and y axis to
-         * represent data value label on the chart
+         * represent data value labels on the chart
          * @private
          */
         function drawAxisLabels() {

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -107,6 +107,10 @@ define(function(require) {
         areaScale,
         colorScale,
 
+        yAxisLabel,
+        yAxisLabelEl,
+        yAxisLabelOffset = -40,
+
         xAxisPadding = {
             top: 0,
             left: 0,
@@ -195,6 +199,8 @@ define(function(require) {
                 .append('g').classed('y-axis-group', true)
                 .append('g').classed('axis y', true);
             container
+                .append('g').classed('axis-labels-group', true);
+            container
                 .append('g').classed('metadata-group', true);
         }
 
@@ -210,6 +216,32 @@ define(function(require) {
 
             svg.select('.y-axis-group .axis.y')
                 .call(yAxis);
+
+            drawAxisLabels();
+        }
+
+        /**
+         * Draws axis labels across axis to
+         * represent data value label on the chart
+         * @private
+         */
+        function drawAxisLabels() {
+            // If y-axis label is given, draw it
+            if (yAxisLabel) {
+                console.log(yAxisLabel)
+                if (yAxisLabelEl) {
+                    svg.selectAll('.y-axis-label-text').remove();
+                }
+
+                yAxisLabelEl = svg.select('.axis-labels-group')
+                    .append('text')
+                    .classed('y-axis-label-text', true)
+                    .attr('x', -chartHeight / 2)
+                    .attr('y', yAxisLabelOffset - xAxisPadding.left)
+                    .attr('text-anchor', 'middle')
+                    .attr('transform', 'rotate(270 0 0)')
+                    .text(yAxisLabel)
+            }
         }
 
         /**
@@ -621,6 +653,39 @@ define(function(require) {
 
             return this;
         };
+
+        /**
+         * Gets or Sets the y-axis label of the chart
+         * @param  {String} _x Desired label string
+         * @return {String | module} Current yAxisLabel or Chart module to chain calls
+         * @public
+         * @example scatterPlot.yAxisLabel('Ice Cream Consmuption Growth')
+         */
+        exports.yAxisLabel = function (_x) {
+            if (!arguments.length) {
+                return yAxisLabel;
+            }
+            yAxisLabel = _x;
+
+            return this;
+        };
+
+        /**
+         * Gets or Sets the offset of the yAxisLabel of the chart.
+         * The method accepts both positive and negative values.
+         * @param  {Number} _x=-40      Desired offset for the label
+         * @return {Number | module}    Current yAxisLabelOffset or Chart module to chain calls
+         * @public
+         * @example scatterPlot.yAxisLabelOffset(-55)
+         */
+        exports.yAxisLabelOffset = function (_x) {
+            if (!arguments.length) {
+                return yAxisLabelOffset;
+            }
+            yAxisLabelOffset = _x;
+
+            return this;
+        }
 
         /**
          * Gets or Sets the xTicks of the chart

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -228,7 +228,6 @@ define(function(require) {
         function drawAxisLabels() {
             // If y-axis label is given, draw it
             if (yAxisLabel) {
-                console.log(yAxisLabel)
                 if (yAxisLabelEl) {
                     svg.selectAll('.y-axis-label-text').remove();
                 }

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -40,6 +40,13 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
             expect(actual).toEqual(expected);
         });
 
+        it('should render axis labels group', () => {
+            let expected = 1;
+            let actual = containerFixture.select('.axis-labels-group').nodes().length;
+
+            expect(actual).toEqual(expected);
+        });
+
         it('should render container, axis and chart groups', () => {
             expect(containerFixture.select('g.container-group').empty()).toBeFalsy();
             expect(containerFixture.select('g.chart-group').empty()).toBeFalsy();
@@ -171,6 +178,30 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
 
                 scatterPlot.xTicks(expected);
                 actual = scatterPlot.xTicks();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
+            it('should provide yAxisLabel getter and setter', () => {
+                let previous = scatterPlot.yAxisLabel(),
+                    expected = 'Ticket Sales',
+                    actual;
+
+                scatterPlot.yAxisLabel(expected);
+                actual = scatterPlot.yAxisLabel();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
+            it('should provide yAxisLabelOffset getter and setter', () => {
+                let previous = scatterPlot.yAxisLabelOffset(-55),
+                    expected = 'Ticket Sales',
+                    actual;
+
+                scatterPlot.yAxisLabelOffset(expected);
+                actual = scatterPlot.yAxisLabelOffset();
 
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);


### PR DESCRIPTION
Added ability to set a custom y-axis label and its offset position with `yAxisLabelOffset`

## Description
Added new methods `yAxisLabel` that accepts string and `yAxisLabelOffset` that accepts a number.

## Motivation and Context
Most of our charts have this

## How Has This Been Tested?
* Added new test for `axis-labels-group` class of the container where y- and x-axis should be placed.
* Added getter/setter tests for them

## Screenshots (if appropriate):
<img width="942" alt="screen shot 2018-03-27 at 9 04 31 pm" src="https://user-images.githubusercontent.com/9118852/38008381-3941e602-3203-11e8-8b98-be26cb279d3b.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
