### PR TITLE
Feature - set custom Scatter Plot aspect ratio

### DIFF
--- a/demos/demo-line.js
+++ b/demos/demo-line.js
@@ -66,7 +66,7 @@ function createLineChart(optionalColorSchema, optionalData) {
         // LineChart Setup and start
         lineChart1
             .isAnimated(true)
-            .aspectRatio(0.5)
+            .aspectRatio(0.4)
             .grid('horizontal')
             .tooltipThreshold(600)
             .width(containerWidth)

--- a/demos/demo-line.js
+++ b/demos/demo-line.js
@@ -66,7 +66,7 @@ function createLineChart(optionalColorSchema, optionalData) {
         // LineChart Setup and start
         lineChart1
             .isAnimated(true)
-            .aspectRatio(0.4)
+            .aspectRatio(0.5)
             .grid('horizontal')
             .tooltipThreshold(600)
             .width(containerWidth)

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -48,6 +48,7 @@ function createScatterPlotWithIncreasedAreaAndHollowCircles() {
         dataset = aTestDataSet().withFourNames().build();
 
         scatter
+            .width(containerWidth)
             .hasHollowCircles(true)
             .maxCircleArea(15);
 

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -24,13 +24,13 @@ function createScatterPlotWithSingleSource() {
         dataset = aTestDataSet().withOneSource().build();
 
         scatter
+            .aspectRatio(0.5)
             .width(containerWidth)
             .circleOpacity(0.6)
             .grid('horizontal')
             .margin({
                 left: 60
             })
-            .aspectRatio(0.3)
             .yAxisLabel('Ice Cream Sales');
 
 
@@ -48,7 +48,6 @@ function createScatterPlotWithIncreasedAreaAndHollowCircles() {
         dataset = aTestDataSet().withFourNames().build();
 
         scatter
-            .width(containerWidth)
             .hasHollowCircles(true)
             .maxCircleArea(15);
 
@@ -59,7 +58,7 @@ function createScatterPlotWithIncreasedAreaAndHollowCircles() {
 // Show charts if container available
 if (d3Selection.select('.js-scatter-plot-with-single-source').node()) {
     createScatterPlotWithSingleSource()
-    // createScatterPlotWithIncreasedAreaAndHollowCircles();
+    createScatterPlotWithIncreasedAreaAndHollowCircles();
 
     redrawCharts = function() {
         d3Selection.selectAll('.scatter-plot').remove();

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -24,7 +24,7 @@ function createScatterPlotWithSingleSource() {
         dataset = aTestDataSet().withOneSource().build();
 
         scatter
-            .aspectRatio(0.5)
+            .aspectRatio(0.7)
             .width(containerWidth)
             .circleOpacity(0.6)
             .grid('horizontal')

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -22,12 +22,13 @@ function createScatterPlotWithSingleSource() {
         dataset = aTestDataSet().withOneSource().build();
 
         scatter
-            .width(750)
+            .width(containerWidth)
             .circleOpacity(0.6)
             .grid('horizontal')
             .margin({
                 left: 60
             })
+            .aspectRatio(0.1)
             .yAxisLabel('Ice Cream Sales');
 
         scatterPlotContainer.datum(dataset).call(scatter);
@@ -44,7 +45,7 @@ function createScatterPlotWithIncreasedAreaAndHollowCircles() {
         dataset = aTestDataSet().withFourNames().build();
 
         scatter
-            .width(750)
+            .width(containerWidth)
             .hasHollowCircles(true)
             .maxCircleArea(15);
 

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -11,6 +11,8 @@ const aTestDataSet = () => new dataBuilder.ScatterPlotDataBuilder();
 
 require('./helpers/resizeHelper');
 
+let redrawCharts;
+
 function createScatterPlotWithSingleSource() {
     let scatter = scatterPlot();
     let scatterPlotContainer = d3Selection.select('.js-scatter-plot-with-single-source');
@@ -28,8 +30,9 @@ function createScatterPlotWithSingleSource() {
             .margin({
                 left: 60
             })
-            .aspectRatio(0.1)
+            .aspectRatio(0.3)
             .yAxisLabel('Ice Cream Sales');
+
 
         scatterPlotContainer.datum(dataset).call(scatter);
     }
@@ -56,9 +59,9 @@ function createScatterPlotWithIncreasedAreaAndHollowCircles() {
 // Show charts if container available
 if (d3Selection.select('.js-scatter-plot-with-single-source').node()) {
     createScatterPlotWithSingleSource()
-    createScatterPlotWithIncreasedAreaAndHollowCircles();
+    // createScatterPlotWithIncreasedAreaAndHollowCircles();
 
-    let redrawCharts = function(){
+    redrawCharts = function() {
         d3Selection.selectAll('.scatter-plot').remove();
         createScatterPlotWithSingleSource();
         createScatterPlotWithIncreasedAreaAndHollowCircles();

--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -11,7 +11,7 @@
                 <h3>The code</h3>
                 <pre><code class="language-javascript">
 scatter
-    .aspectRatio(0.5)
+    .aspectRatio(0.7)
     .width(containerWidth)
     .circleOpacity(0.6)
     .grid('horizontal')

--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -11,7 +11,8 @@
                 <h3>The code</h3>
                 <pre><code class="language-javascript">
 scatter
-    .width(750)
+    .aspectRatio(0.5)
+    .width(containerWidth)
     .circleOpacity(0.6)
     .grid('horizontal')
     .margin({

--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -44,7 +44,7 @@ container.datum(dataset).call(lineChart);
                 <h3>The code</h3>
                 <pre><code class="language-javascript">
 scatter
-    .width(750)
+    .width(containerWidth)
     .hasHollowCircles(true)
     .maxCircleArea(15);
 

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -65,8 +65,9 @@ define(function(require) {
      * let scatterPlot = scatterPlot();
      *
      * scatterPlot
-     *     .width(500)
-     *     .aspectRatio(0.5);
+     *     .aspectRatio(0.5)
+     *     .grid('horizontal')
+     *     .width(500);
      *
      * d3Selection.select('.css-selector')
      *     .datum(dataset)

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -82,6 +82,7 @@ define(function(require) {
         },
         width = 960,
         height = 500,
+        aspectRatio = null,
 
         nameColorMap,
 
@@ -469,6 +470,41 @@ define(function(require) {
         // API
 
         /**
+         * Gets or Sets the aspect ratio of the chart
+         * @param  {Number} _x            Desired aspect ratio for the graph
+         * @return {aspectRatio | module} Current aspect ratio or Chart module to chain calls
+         * @public
+         */
+        exports.aspectRatio = function (_x) {
+            if (!arguments.length) {
+                return aspectRatio;
+            }
+            aspectRatio = _x;
+
+            return this;
+        };
+
+        /**
+         * Gets or Sets the circles opacity value of the chart.
+         * Sets opacity of a circle for each data point of the chart and
+         * makes the area of each data point more transparent if it's less than 1.
+         * @param  {Number} _x=1               Desired opacity of circles of the chart
+         * @return {circleOpacity | module}    Current circleOpacity or Scatter Chart module to chain calls
+         * @public
+         * @example
+         * scatterPlot.circleOpacity(0.6)
+         */
+        exports.circleOpacity = function (_x) {
+            if (!arguments.length) {
+                return circleOpacity;
+            }
+            circleOpacity = _x;
+
+            return this;
+        }
+
+
+        /**
          * Gets or Sets the colorSchema of the chart
          * @param  {String[]} _x            Desired colorSchema for the chart
          * @return {colorSchema | module}   Current colorSchema or Chart module to chain calls
@@ -486,23 +522,14 @@ define(function(require) {
         };
 
         /**
-         * Gets or Sets the circles opacity value of the chart.
-         * Sets opacity of a circle for each data point of the chart and
-         * makes the area of each data point more transparent if it's less than 1.
-         * @param  {number} _x=1               Desired opacity of circles of the chart
-         * @return {circleOpacity | module}    Current circleOpacity or Scatter Chart module to chain calls
+         * Chart exported to png and a download action is fired
+         * @param {String} filename     File title for the resulting picture
+         * @param {String} title        Title to add at the top of the exported picture
          * @public
-         * @example
-         * scatterPlot.circleOpacity(0.6)
          */
-        exports.circleOpacity = function (_x) {
-            if (!arguments.length) {
-                return circleOpacity;
-            }
-            circleOpacity = _x;
-
-            return this;
-        }
+        exports.exportChart = function (filename, title) {
+            exportChart.call(exports, svg, filename, title);
+        };
 
         /**
          * Gets or Sets the grid mode.
@@ -511,23 +538,13 @@ define(function(require) {
          * @return {String | module} Current mode of the grid or Area Chart module to chain calls
          * @public
          */
-        exports.grid = function(_x) {
+        exports.grid = function (_x) {
             if (!arguments.length) {
                 return grid;
             }
             grid = _x;
 
             return this;
-        };
-
-        /**
-         * Chart exported to png and a download action is fired
-         * @param {String} filename     File title for the resulting picture
-         * @param {String} title        Title to add at the top of the exported picture
-         * @public
-         */
-        exports.exportChart = function (filename, title) {
-            exportChart.call(exports, svg, filename, title);
         };
 
         /**
@@ -544,6 +561,24 @@ define(function(require) {
 
             return this;
         }
+
+        /**
+         * Gets or Sets the height of the chart
+         * @param  {Number} _x          Desired height for the chart
+         * @return {height | module}    Current height or Scatter Chart module to chain calls
+         * @public
+         */
+        exports.height = function (_x) {
+            if (!arguments.length) {
+                return height;
+            }
+            if (aspectRatio) {
+                width = Math.ceil(_x / aspectRatio);
+            }
+            height = _x;
+
+            return this;
+        };
 
         /**
          * Gets or Sets isAnimated value. If set to true,
@@ -581,7 +616,7 @@ define(function(require) {
 
         /**
          * Gets or Sets the maximum value of the chart area
-         * @param  {number} _x=10       Desired margin object properties for each side
+         * @param  {Number} _x=10       Desired margin object properties for each side
          * @return {maxCircleArea | module}    Current height or Scatter Chart module to chain calls
          * @public
          */
@@ -593,21 +628,6 @@ define(function(require) {
 
             return this;
         }
-
-        /**
-         * Gets or Sets the height of the chart
-         * @param  {Number} _x          Desired height for the chart
-         * @return {height | module}    Current height or Scatter Chart module to chain calls
-         * @public
-         */
-        exports.height = function(_x) {
-            if (!arguments.length) {
-                return height;
-            }
-            height = _x;
-
-            return this;
-        };
 
         /**
          * Exposes an 'on' method that acts as a bridge with the event dispatcher
@@ -633,6 +653,9 @@ define(function(require) {
             if (!arguments.length) {
                 return width;
             }
+            if (aspectRatio) {
+                height = Math.ceil(_x * aspectRatio);
+            }
             width = _x;
 
             return this;
@@ -656,7 +679,7 @@ define(function(require) {
         /**
          * Gets or Sets the y-axis label of the chart
          * @param  {String} _x Desired label string
-         * @return {String | module} Current yAxisLabel or Chart module to chain calls
+         * @return {yAxisLabel | module} Current yAxisLabel or Chart module to chain calls
          * @public
          * @example scatterPlot.yAxisLabel('Ice Cream Consmuption Growth')
          */
@@ -673,7 +696,7 @@ define(function(require) {
          * Gets or Sets the offset of the yAxisLabel of the chart.
          * The method accepts both positive and negative values.
          * @param  {Number} _x=-40      Desired offset for the label
-         * @return {Number | module}    Current yAxisLabelOffset or Chart module to chain calls
+         * @return {yAxisLabelOffset | module}    Current yAxisLabelOffset or Chart module to chain calls
          * @public
          * @example scatterPlot.yAxisLabelOffset(-55)
          */

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -71,6 +71,18 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
 
         describe('API', function() {
 
+            it('should provide an aspect ratio getter and setter', () => {
+                let previous = scatterPlot.aspectRatio(),
+                    expected = 600,
+                    actual;
+
+                scatterPlot.aspectRatio(expected);
+                actual = scatterPlot.aspectRatio();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
             it('should provide circleOpacity getter and setter', () => {
                 let previous = scatterPlot.circleOpacity(),
                     expected = 0.6,

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -244,6 +244,36 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
             });
         });
 
+        describe('Aspect Ratio', () => {
+
+            describe('when an aspect ratio is set', function () {
+
+                it('should modify the height depending on the width', () => {
+                    let testAspectRatio = 0.5,
+                        testWidth = 400,
+                        newHeight;
+
+                    scatterPlot.aspectRatio(testAspectRatio);
+                    scatterPlot.width(testWidth);
+                    newHeight = scatterPlot.height();
+
+                    expect(newHeight).toBe(Math.ceil(testWidth * testAspectRatio));
+                });
+
+                it('should modify the width depending on the height', () => {
+                    let testAspectRatio = 0.5,
+                        testHeight = 400,
+                        newWidth;
+
+                    scatterPlot.aspectRatio(testAspectRatio);
+                    scatterPlot.height(testHeight);
+                    newWidth = scatterPlot.width();
+
+                    expect(newWidth).toBe(Math.ceil(testHeight / testAspectRatio));
+                });
+            });
+        });
+
         describe('when margins are set partially', function() {
 
             it('should override the default values', () => {


### PR DESCRIPTION
_Scatter plot changes:_
## Description
- added new function `aspectRatio` that sets the aspect ratio of the chart
- reorganized chart's method in alphabetical order

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
API function exists in most (if not all) charts

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Setter/getter test
* Expected value of the chart property test

## Screenshots (if appropriate):
`scatterPlot.aspectRatio(0.4)`:
![scatter_aspect_ratio_0 4](https://user-images.githubusercontent.com/31934144/38014854-d9ecb314-321e-11e8-8adb-f50a0f6d26af.png)

`scatterPlot.aspectRatio(0.8)`:
![screen shot 2018-03-28 at 12 28 13 am](https://user-images.githubusercontent.com/31934144/38014895-f790f484-321e-11e8-8fae-0e3cde1f4738.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
