### PR TITLE
Feature - Scatter plot x-axis label with offset with more tests

### DIFF
--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -28,7 +28,7 @@ function createScatterPlotWithSingleSource() {
             .width(containerWidth)
             .circleOpacity(0.6)
             .grid('horizontal')
-            .xAxisLabel('Hello')
+            .xAxisLabel('Temperature (C)')
             .margin({
                 left: 60,
                 bottom: 50

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -14,7 +14,7 @@ require('./helpers/resizeHelper');
 let redrawCharts;
 
 function createScatterPlotWithSingleSource() {
-    let scatter = scatterPlot();
+    let scatterChart = scatterPlot();
     let scatterPlotContainer = d3Selection.select('.js-scatter-plot-with-single-source');
     let containerWidth = scatterPlotContainer.node() ? scatterPlotContainer.node().getBoundingClientRect().width : false;
     let dataset;
@@ -23,7 +23,7 @@ function createScatterPlotWithSingleSource() {
         // data represents Ice Cream Sales (y) vs Temperature (x)
         dataset = aTestDataSet().withOneSource().build();
 
-        scatter
+        scatterChart
             .aspectRatio(0.7)
             .width(containerWidth)
             .circleOpacity(0.6)
@@ -36,7 +36,7 @@ function createScatterPlotWithSingleSource() {
             .yAxisLabel('Ice Cream Sales');
 
 
-        scatterPlotContainer.datum(dataset).call(scatter);
+        scatterPlotContainer.datum(dataset).call(scatterChart);
     }
 }
 
@@ -49,12 +49,12 @@ function createScatterPlotWithIncreasedAreaAndHollowCircles() {
     if (containerWidth) {
         dataset = aTestDataSet().withFourNames().build();
 
-        scatter
+        scatterChart
             .width(containerWidth)
             .hasHollowCircles(true)
             .maxCircleArea(15);
 
-        scatterPlotContainer.datum(dataset).call(scatter);
+        scatterPlotContainer.datum(dataset).call(scatterChart);
     }
 }
 

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -41,7 +41,7 @@ function createScatterPlotWithSingleSource() {
 }
 
 function createScatterPlotWithIncreasedAreaAndHollowCircles() {
-    let scatter = scatterPlot();
+    let scatterChart = scatterPlot();
     let scatterPlotContainer = d3Selection.select('.js-scatter-plot-container-with-hollow-circles');
     let containerWidth = scatterPlotContainer.node() ? scatterPlotContainer.node().getBoundingClientRect().width : false;
     let dataset;

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -28,8 +28,10 @@ function createScatterPlotWithSingleSource() {
             .width(containerWidth)
             .circleOpacity(0.6)
             .grid('horizontal')
+            .xAxisLabel('Hello')
             .margin({
-                left: 60
+                left: 60,
+                bottom: 50
             })
             .yAxisLabel('Ice Cream Sales');
 

--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -10,7 +10,7 @@
             <div class="col-md-4 sidebar">
                 <h3>The code</h3>
                 <pre><code class="language-javascript">
-scatter
+scatterChart
     .aspectRatio(0.7)
     .width(containerWidth)
     .circleOpacity(0.6)
@@ -20,7 +20,7 @@ scatter
     })
     .yAxisLabel('Ice Cream Sales');
 
-container.datum(dataset).call(scatter);
+container.datum(dataset).call(scatterChart);
                 </code></pre>
                 <h4>Colors</h4>
                 <label class="control-label">You can also check other color schemas:</label>
@@ -43,12 +43,12 @@ container.datum(dataset).call(scatter);
             <div class="col-md-4 sidebar">
                 <h3>The code</h3>
                 <pre><code class="language-javascript">
-scatter
+scatterChart
     .width(containerWidth)
     .hasHollowCircles(true)
     .maxCircleArea(15);
 
-container.datum(dataset).call(scatter);
+container.datum(dataset).call(scatterChart);
                 </code></pre>
                 <h4>Colors</h4>
                 <label class="control-label">You can also check other color schemas:</label>

--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -15,12 +15,17 @@ scatterChart
     .width(containerWidth)
     .circleOpacity(0.6)
     .grid('horizontal')
+    .xAxisLabel('Temperature (C)')
     .margin({
-        left: 60
+        left: 60,
+        bottom: 50
     })
     .yAxisLabel('Ice Cream Sales');
 
-container.datum(dataset).call(scatterChart);
+
+scatterPlotContainer
+    .datum(dataset)
+    .call(scatterChart);
                 </code></pre>
                 <h4>Colors</h4>
                 <label class="control-label">You can also check other color schemas:</label>
@@ -48,7 +53,9 @@ scatterChart
     .hasHollowCircles(true)
     .maxCircleArea(15);
 
-container.datum(dataset).call(scatterChart);
+container
+    .datum(dataset)
+    .call(scatterChart);
                 </code></pre>
                 <h4>Colors</h4>
                 <label class="control-label">You can also check other color schemas:</label>

--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -20,7 +20,7 @@ scatter
     })
     .yAxisLabel('Ice Cream Sales');
 
-container.datum(dataset).call(lineChart);
+container.datum(dataset).call(scatter);
                 </code></pre>
                 <h4>Colors</h4>
                 <label class="control-label">You can also check other color schemas:</label>
@@ -48,7 +48,7 @@ scatter
     .hasHollowCircles(true)
     .maxCircleArea(15);
 
-container.datum(dataset).call(lineChart);
+container.datum(dataset).call(scatter);
                 </code></pre>
                 <h4>Colors</h4>
                 <label class="control-label">You can also check other color schemas:</label>

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -112,6 +112,9 @@ define(function(require) {
         yAxisLabel,
         yAxisLabelEl,
         yAxisLabelOffset = -40,
+        xAxisLabel,
+        xAxisLabelEl,
+        xAxisLabelOffset = -40,
 
         xAxisPadding = {
             top: 0,
@@ -242,6 +245,21 @@ define(function(require) {
                     .attr('text-anchor', 'middle')
                     .attr('transform', 'rotate(270 0 0)')
                     .text(yAxisLabel)
+            }
+
+            // If x-axis label is given, draw it
+            if (xAxisLabel) {
+                if (xAxisLabelEl) {
+                    svg.selectAll('.x-axis-label-text').remove();
+                }
+
+                xAxisLabelEl = svg.select('.axis-labels-group')
+                    .append('text')
+                    .classed('x-axis-label-text', true)
+                    .attr('x', chartWidth / 2)
+                    .attr('y', chartHeight - xAxisLabelOffset)
+                    .attr('text-anchor', 'middle')
+                    .text(xAxisLabel);
             }
         }
 
@@ -658,6 +676,22 @@ define(function(require) {
                 height = Math.ceil(_x * aspectRatio);
             }
             width = _x;
+
+            return this;
+        };
+
+        /**
+         * Gets or Sets the xAxisLabel of the chart. Adds a
+         * label bellow x-axis for better clarify of data representation.
+         * @param  {String} _x              Desired string for x-axis label of the chart
+         * @return {xAxisLabel | module}    Current width or Scatter Chart module to chain calls
+         * @public
+         */
+        exports.xAxisLabel = function(_x) {
+            if (!arguments.length) {
+                return xAxisLabel;
+            }
+            xAxisLabel = _x;
 
             return this;
         };

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -697,6 +697,23 @@ define(function(require) {
         };
 
         /**
+         * Gets or Sets the offset of the xAxisLabel of the chart.
+         * The method accepts both positive and negative values.
+         * @param  {Number} _x=-40                Desired offset for the label
+         * @return {xAxisLabelOffset | module}    Current xAxisLabelOffset or Chart module to chain calls
+         * @public
+         * @example scatterPlot.xAxisLabelOffset(-55)
+         */
+        exports.xAxisLabelOffset = function (_x) {
+            if (!arguments.length) {
+                return xAxisLabelOffset;
+            }
+            xAxisLabelOffset = _x;
+
+            return this;
+        };
+
+        /**
          * Gets or Sets the xTicks of the chart
          * @param  {Number} _x         Desired height for the chart
          * @return {xTicks | module}    Current width or Scatter Chart module to chain calls

--- a/src/charts/step.js
+++ b/src/charts/step.js
@@ -480,7 +480,7 @@ define(function(require) {
         /**
          * Gets or Sets the text of the xAxisLabel on the chart
          * @param  {String} _x Desired text for the label
-         * @return {xAxisLabel | module} label or Chart module to chain calls
+         * @return {String | module} label or Chart module to chain calls
          * @public
          */
         exports.xAxisLabel = function(_x) {
@@ -494,7 +494,7 @@ define(function(require) {
         /**
          * Gets or Sets the offset of the xAxisLabel on the chart
          * @param  {Number} _x Desired offset for the label
-         * @return {xAxisLabelOffset | module} label or Chart module to chain calls
+         * @return {Number | module} label or Chart module to chain calls
          * @public
          */
         exports.xAxisLabelOffset = function(_x) {
@@ -508,7 +508,7 @@ define(function(require) {
         /**
          * Gets or Sets the text of the yAxisLabel on the chart
          * @param  {String} _x Desired text for the label
-         * @return {yAxisLabel | module} label or Chart module to chain calls
+         * @return {String | module} label or Chart module to chain calls
          * @public
          */
         exports.yAxisLabel = function(_x) {
@@ -522,7 +522,7 @@ define(function(require) {
         /**
          * Gets or Sets the offset of the yAxisLabel on the chart
          * @param  {Number} _x Desired offset for the label
-         * @return {yAxisLabelOffset | module} label or Chart module to chain calls
+         * @return {Number | module} label or Chart module to chain calls
          * @public
          */
         exports.yAxisLabelOffset = function(_x) {

--- a/src/charts/step.js
+++ b/src/charts/step.js
@@ -479,8 +479,8 @@ define(function(require) {
 
         /**
          * Gets or Sets the text of the xAxisLabel on the chart
-         * @param  {text} _x Desired text for the label
-         * @return { text | module} label or Chart module to chain calls
+         * @param  {String} _x Desired text for the label
+         * @return {xAxisLabel | module} label or Chart module to chain calls
          * @public
          */
         exports.xAxisLabel = function(_x) {
@@ -493,8 +493,8 @@ define(function(require) {
 
         /**
          * Gets or Sets the offset of the xAxisLabel on the chart
-         * @param  {integer} _x Desired offset for the label
-         * @return { integer | module} label or Chart module to chain calls
+         * @param  {Number} _x Desired offset for the label
+         * @return {xAxisLabelOffset | module} label or Chart module to chain calls
          * @public
          */
         exports.xAxisLabelOffset = function(_x) {
@@ -507,8 +507,8 @@ define(function(require) {
 
         /**
          * Gets or Sets the text of the yAxisLabel on the chart
-         * @param  {text} _x Desired text for the label
-         * @return { text | module} label or Chart module to chain calls
+         * @param  {String} _x Desired text for the label
+         * @return {yAxisLabel | module} label or Chart module to chain calls
          * @public
          */
         exports.yAxisLabel = function(_x) {
@@ -521,8 +521,8 @@ define(function(require) {
 
         /**
          * Gets or Sets the offset of the yAxisLabel on the chart
-         * @param  {integer} _x Desired offset for the label
-         * @return { integer | module} label or Chart module to chain calls
+         * @param  {Number} _x Desired offset for the label
+         * @return {yAxisLabelOffset | module} label or Chart module to chain calls
          * @public
          */
         exports.yAxisLabelOffset = function(_x) {

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -330,5 +330,69 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
                 expect(callbackSpy.calls.allArgs()[0].length).toBe(3);
             });
         });
+
+        describe('when axis labels are set', () => {
+            let scatterPlot, dataset, containerFixture, f;
+
+            beforeEach(() => {
+                dataset = buildDataSet('withOneSource');
+                scatterPlot = chart()
+                    .xAxisLabel('Hello World')
+                    .yAxisLabel('Goodbye World');
+
+                // DOM Fixture Setup
+                f = jasmine.getFixtures();
+                f.fixturesPath = 'base/test/fixtures/';
+                f.load('testContainer.html');
+
+                containerFixture = d3.select('.test-container');
+                containerFixture.datum(dataset).call(scatterPlot);
+            });
+
+            afterEach(() => {
+                containerFixture.remove();
+                f = jasmine.getFixtures();
+                f.cleanUp();
+                f.clearCache();
+            });
+
+            describe('when x-axis label and offset are set', () => {
+
+                it('should render the x axis label', () => {
+                    let expected = 1;
+                    let actual = containerFixture.select('svg')
+                        .selectAll('.axis-labels-group .x-axis-label-text').nodes().length;
+
+                    expect(actual).toBe(expected);
+                })
+
+                it('label should have correct string', () => {
+                    let expected = 'Hello World';
+                    let actual = containerFixture.select('svg')
+                        .selectAll('.axis-labels-group .x-axis-label-text').text();
+
+                    expect(actual).toBe(expected);
+                })
+            });
+
+            describe('when y-axis label and offset are set', () => {
+
+                it('should render the x axis label', () => {
+                    let expected = 1;
+                    let actual = containerFixture.select('svg')
+                        .selectAll('.axis-labels-group .y-axis-label-text').nodes().length;
+
+                    expect(actual).toBe(expected);
+                })
+
+                it('label should have correct string', () => {
+                    let expected = 'Goodbye World';
+                    let actual = containerFixture.select('svg')
+                        .selectAll('.axis-labels-group .y-axis-label-text').text();
+
+                    expect(actual).toBe(expected);
+                })
+            });
+        });
     });
 });

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -183,6 +183,30 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
                 expect(actual).toEqual(expected);
             });
 
+            it('should provide xAxisLabel getter and setter', () => {
+                let previous = scatterPlot.xAxisLabel(),
+                    expected = 'Great chart',
+                    actual;
+
+                scatterPlot.xAxisLabel(expected);
+                actual = scatterPlot.xAxisLabel();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
+            it('should provide xAxisLabelOffset getter and setter', () => {
+                let previous = scatterPlot.xAxisLabelOffset(),
+                    expected = 40,
+                    actual;
+
+                scatterPlot.xAxisLabelOffset(expected);
+                actual = scatterPlot.xAxisLabelOffset();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
             it('should provide xTicks getter and setter', () => {
                 let previous = scatterPlot.xTicks(),
                     expected = 48,

--- a/test/specs/step.spec.js
+++ b/test/specs/step.spec.js
@@ -210,7 +210,7 @@ define([
         });
 
         describe('when margins are set partially', function() {
-            
+
             it('should override the default values', () => {
                 let previous = stepChart.margin(),
                 expected = {
@@ -226,7 +226,7 @@ define([
                 expect(previous).not.toBe(actual);
                 expect(actual).toEqual(expected);
             })
-        });   
+        });
 
         describe('when hovering a step', function() {
 


### PR DESCRIPTION
Added ability to set custom x-axis label

## Description
Added x-axis custom label setter function with tests, also added more descriptive, DOM-inspection test for y axis label.

## Motivation and Context
Basic API method for charts

## How Has This Been Tested?
* Added setter/getter test for x-axis label
* Added DOM inspection test for x-axis label
* Added DOM inspection test for y-axis label

## Screenshots (if appropriate):
<img width="1113" alt="screen shot 2018-03-28 at 8 05 15 pm" src="https://user-images.githubusercontent.com/31934144/38069081-59893386-32c9-11e8-88d4-f1fecc6dc676.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
