### PR TITLE
Fixes spacing below color selector and plugs it to scatter plot demo

### DIFF
--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -6,6 +6,7 @@ const PubSub = require('pubsub-js');
 const scatterPlot = require('./../src/charts/scatter-plot');
 const colors = require('./../src/charts/helpers/color');
 const dataBuilder = require('./../test/fixtures/scatterPlotDataBuilder');
+const colorSelectorHelper = require('./helpers/colorSelector');
 
 const aTestDataSet = () => new dataBuilder.ScatterPlotDataBuilder();
 
@@ -13,7 +14,7 @@ require('./helpers/resizeHelper');
 
 let redrawCharts;
 
-function createScatterPlotWithSingleSource() {
+function createScatterPlotWithSingleSource(optionalColorSchema) {
     let scatterChart = scatterPlot();
     let scatterPlotContainer = d3Selection.select('.js-scatter-plot-with-single-source');
     let containerWidth = scatterPlotContainer.node() ? scatterPlotContainer.node().getBoundingClientRect().width : false;
@@ -35,6 +36,9 @@ function createScatterPlotWithSingleSource() {
             })
             .yAxisLabel('Ice Cream Sales');
 
+        if (optionalColorSchema) {
+            scatterChart.colorSchema(optionalColorSchema);
+        }
 
         scatterPlotContainer.datum(dataset).call(scatterChart);
     }
@@ -71,4 +75,9 @@ if (d3Selection.select('.js-scatter-plot-with-single-source').node()) {
 
     // Redraw charts on window resize
     PubSub.subscribe('resize', redrawCharts);
+
+    // Color schema selector
+    colorSelectorHelper.createColorSelector('.js-color-selector-container', '.scatter-plot', function (newSchema) {
+        createScatterPlotWithSingleSource(newSchema);
+    });
 }

--- a/demos/grouped-bar.html
+++ b/demos/grouped-bar.html
@@ -29,7 +29,7 @@ tooltipContainer.datum([]).call(chartTooltip);
                 </code></pre>
                 <h4>Colors</h4>
                 <label class="control-label">You can also check other color schemas:</label>
-                <div class="js-color-selector-container card--chart"></div>
+                <div class="js-color-selector-container"></div>
                 <h4>Data Input</h4>
                 <p>Check the <a href="/britecharts/global.html#GroupedBarChartData__anchor">data input schema</a> of this chart.</p>
                 <h4>Export Chart</h4>

--- a/demos/line.html
+++ b/demos/line.html
@@ -27,7 +27,7 @@ container.datum(dataset).call(lineChart);
                 </code></pre>
                 <h4>Colors</h4>
                 <label class="control-label">You can also check other color schemas:</label>
-                <div class="js-color-selector-container card--chart"></div>
+                <div class="js-color-selector-container"></div>
                 <h4>Data Input</h4>
                 <p>Check the <a href="/britecharts/global.html#LineChartData__anchor">data input schema</a> of this chart.</p>
                 <h4>Export Chart</h4>

--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -29,7 +29,7 @@ scatterPlotContainer
                 </code></pre>
                 <h4>Colors</h4>
                 <label class="control-label">You can also check other color schemas:</label>
-                <div class="js-color-selector-container card--chart"></div>
+                <div class="js-color-selector-container"></div>
                 <h4>Data Input</h4>
                 <p>Check the <a href="/britecharts/global.html#LineChartData__anchor">data input schema</a> of this chart.</p>
                 <h4>Export Chart</h4>
@@ -59,7 +59,7 @@ container
                 </code></pre>
                 <h4>Colors</h4>
                 <label class="control-label">You can also check other color schemas:</label>
-                <div class="js-color-selector-container card--chart"></div>
+                <div class="js-color-selector-container"></div>
                 <h4>Data Input</h4>
                 <p>Check the <a href="/britecharts/global.html#LineChartData__anchor">data input schema</a> of this chart.</p>
                 <h4>Export Chart</h4>

--- a/demos/stacked-area.html
+++ b/demos/stacked-area.html
@@ -28,7 +28,7 @@ tooltipContainer.datum([]).call(chartTooltip);
                 </code></pre>
                 <h4>Colors</h4>
                 <label class="control-label">You can also check other color schemas:</label>
-                <div class="js-color-selector-container card--chart"></div>
+                <div class="js-color-selector-container"></div>
                 <h4>Data Input</h4>
                 <p>Check the <a href="/britecharts/global.html#areaChartData__anchor">data input schema</a> of this chart.</p>
                 <h4>Export Chart</h4>

--- a/demos/stacked-bar.html
+++ b/demos/stacked-bar.html
@@ -33,7 +33,7 @@ tooltipContainer.datum([]).call(chartTooltip);
                 </code></pre>
                 <h4>Colors</h4>
                 <label class="control-label">You can also check other color schemas:</label>
-                <div class="js-color-selector-container card--chart"></div>
+                <div class="js-color-selector-container"></div>
                 <h4>Data Input</h4>
                 <p>Check the <a href="http://eventbrite.github.io/britecharts/global.html#stackedBarData__anchor">data input schema</a> of this chart.</p>
                 <h4>Export Chart</h4>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed empty space after color selectors all over the place
Added color selector to Scatter plot demo

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixing spacing problem and fixing Scatter Plot demo

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked manually

## Screenshots (if appropriate):
<img width="1680" alt="fullscreen_3_29_18__5_22_pm" src="https://user-images.githubusercontent.com/190833/38119338-da7adf60-3375-11e8-91ae-ac84b6a8c51b.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

