### PR TITLE
Addressed design notes and added x and y axis formatter functions

### DIFF
--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -35,6 +35,7 @@ function createScatterPlotWithSingleSource(optionalColorSchema) {
                 bottom: 50
             })
             .yAxisLabel('Ice Cream Sales')
+            .xAxisFormat('')
             .yAxisFormat('$');
 
         if (optionalColorSchema) {

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -34,7 +34,8 @@ function createScatterPlotWithSingleSource(optionalColorSchema) {
                 left: 60,
                 bottom: 50
             })
-            .yAxisLabel('Ice Cream Sales');
+            .yAxisLabel('Ice Cream Sales')
+            .yAxisFormat('$');
 
         if (optionalColorSchema) {
             scatterChart.colorSchema(optionalColorSchema);

--- a/demos/demo-scatter-plot.js
+++ b/demos/demo-scatter-plot.js
@@ -35,7 +35,6 @@ function createScatterPlotWithSingleSource(optionalColorSchema) {
                 bottom: 50
             })
             .yAxisLabel('Ice Cream Sales')
-            .xAxisFormat('')
             .yAxisFormat('$');
 
         if (optionalColorSchema) {

--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -20,7 +20,8 @@ scatterChart
         left: 60,
         bottom: 50
     })
-    .yAxisLabel('Ice Cream Sales');
+    .yAxisLabel('Ice Cream Sales')
+    .yAxisFormat('$');
 
 
 scatterPlotContainer

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -103,9 +103,10 @@ define(function(require) {
         maskGridLines,
 
         xAxis,
+        xAxisFormat = '',
         xScale,
         yAxis,
-        yAxisFormat = null,
+        yAxisFormat = '',
         yScale,
         areaScale,
         colorScale,
@@ -176,7 +177,8 @@ define(function(require) {
         function buildAxis() {
             xAxis = d3Axis.axisBottom(xScale)
                 .ticks(xTicks)
-                .tickPadding(tickPadding);
+                .tickPadding(tickPadding)
+                .tickFormat(d3Format.format(xAxisFormat));
 
             yAxis = d3Axis.axisLeft(yScale)
                 .ticks(yTicks)

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -102,10 +102,11 @@ define(function(require) {
         baseLine,
         maskGridLines,
 
-        xScale,
         xAxis,
-        yScale,
+        xScale,
         yAxis,
+        yAxisFormat = null,
+        yScale,
         areaScale,
         colorScale,
 
@@ -179,7 +180,8 @@ define(function(require) {
 
             yAxis = d3Axis.axisLeft(yScale)
                 .ticks(yTicks)
-                .tickPadding(tickPadding);
+                .tickPadding(tickPadding)
+                .tickFormat(d3Format.format(yAxisFormat));
         }
 
         /**
@@ -731,6 +733,21 @@ define(function(require) {
 
             return this;
         };
+
+        /**
+         * Exposes ability to set the format of y-axis values
+         * @param  {String} _x         Desired height for the chart
+         * @return {yAxisFormat | module}    Current width or Scatter Chart module to chain calls
+         * @public
+         */
+        exports.yAxisFormat = function(_x) {
+            if (!arguments.length) {
+                return yAxisFormat;
+            }
+            yAxisFormat = _x;
+
+            return this;
+        }
 
         /**
          * Gets or Sets the y-axis label of the chart

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -722,6 +722,21 @@ define(function(require) {
         };
 
         /**
+         * Exposes ability to set the format of x-axis values
+         * @param  {String} _x               Desired height for the chart
+         * @return {yAxisFormat | module}    Current width or Scatter Chart module to chain calls
+         * @public
+         */
+        exports.xAxisFormat = function (_x) {
+            if (!arguments.length) {
+                return xAxisFormat;
+            }
+            xAxisFormat = _x;
+
+            return this;
+        };
+
+        /**
          * Gets or Sets the xTicks of the chart
          * @param  {Number} _x         Desired height for the chart
          * @return {xTicks | module}    Current width or Scatter Chart module to chain calls
@@ -738,7 +753,7 @@ define(function(require) {
 
         /**
          * Exposes ability to set the format of y-axis values
-         * @param  {String} _x         Desired height for the chart
+         * @param  {String} _x               Desired height for the chart
          * @return {yAxisFormat | module}    Current width or Scatter Chart module to chain calls
          * @public
          */

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -123,7 +123,7 @@ define(function(require) {
             right: 0
         },
 
-        circleOpacity = 1,
+        circleOpacity = 0.24,
         maxCircleArea = 10,
 
         colorSchema = colorHelper.colorSchemas.britecharts,
@@ -238,13 +238,15 @@ define(function(require) {
                 }
 
                 yAxisLabelEl = svg.select('.axis-labels-group')
-                    .append('text')
-                    .classed('y-axis-label-text', true)
-                    .attr('x', -chartHeight / 2)
-                    .attr('y', yAxisLabelOffset - xAxisPadding.left)
-                    .attr('text-anchor', 'middle')
-                    .attr('transform', 'rotate(270 0 0)')
-                    .text(yAxisLabel)
+                    .append('g')
+                    .attr('class', 'y-axis-label')
+                      .append('text')
+                      .classed('y-axis-label-text', true)
+                      .attr('x', -chartHeight / 2)
+                      .attr('y', yAxisLabelOffset - xAxisPadding.left)
+                      .attr('text-anchor', 'middle')
+                      .attr('transform', 'rotate(270 0 0)')
+                      .text(yAxisLabel)
             }
 
             // If x-axis label is given, draw it
@@ -253,13 +255,15 @@ define(function(require) {
                     svg.selectAll('.x-axis-label-text').remove();
                 }
 
-                xAxisLabelEl = svg.select('.axis-labels-group')
-                    .append('text')
-                    .classed('x-axis-label-text', true)
-                    .attr('x', chartWidth / 2)
-                    .attr('y', chartHeight - xAxisLabelOffset)
-                    .attr('text-anchor', 'middle')
-                    .text(xAxisLabel);
+                xAxisLabelEl = svg.selectAll('.axis-labels-group')
+                    .append('g')
+                    .attr('class', 'x-axis-label')
+                      .append('text')
+                      .classed('x-axis-label-text', true)
+                      .attr('x', chartWidth / 2)
+                      .attr('y', chartHeight - xAxisLabelOffset)
+                      .attr('text-anchor', 'middle')
+                      .text(xAxisLabel);
             }
         }
 
@@ -505,9 +509,9 @@ define(function(require) {
 
         /**
          * Gets or Sets the circles opacity value of the chart.
-         * Sets opacity of a circle for each data point of the chart and
-         * makes the area of each data point more transparent if it's less than 1.
-         * @param  {Number} _x=1               Desired opacity of circles of the chart
+         * Use this to set opacity of a circle for each data point of the chart.
+         * It makes the area of each data point more transparent if it's less than 1.
+         * @param  {Number} _x=0.24            Desired opacity of circles of the chart
          * @return {circleOpacity | module}    Current circleOpacity or Scatter Chart module to chain calls
          * @public
          * @example

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -451,16 +451,14 @@ define(function(require) {
                     .ease(ease)
                     .attr('class', 'point')
                     .attr('class', 'data-point-highlighter')
-                    .style('stroke', (d) => (
-                        hasHollowCircles ? nameColorMap[d.name] : null
-                    ))
-                    .attr('opacity', circleOpacity)
-                    .attr('r', (d) => areaScale(d.y))
-                    .attr('cx', (d) => xScale(d.x))
-                    .attr('cy', (d) => yScale(d.y))
+                    .style('stroke', (d) => nameColorMap[d.name])
                     .attr('fill', (d) => (
                         hasHollowCircles ? hollowColor : nameColorMap[d.name]
                     ))
+                    .attr('fill-opacity', circleOpacity)
+                    .attr('r', (d) => areaScale(d.y))
+                    .attr('cx', (d) => xScale(d.x))
+                    .attr('cy', (d) => yScale(d.y))
                     .style('cursor', 'pointer');
             } else {
                 circles
@@ -470,16 +468,14 @@ define(function(require) {
                       })
                       .attr('class', 'point')
                       .attr('class', 'data-point-highlighter')
-                      .style('stroke', (d) => (
-                          hasHollowCircles ? nameColorMap[d.name] : null
+                      .style('stroke', (d) => nameColorMap[d.name])
+                      .attr('fill', (d) => (
+                        hasHollowCircles ? hollowColor : nameColorMap[d.name]
                       ))
-                      .attr('opacity', circleOpacity)
+                      .attr('fill-opacity', circleOpacity)
                       .attr('r', (d) => areaScale(d.y))
                       .attr('cx', (d) => xScale(d.x))
                       .attr('cy', (d) => yScale(d.y))
-                      .attr('fill', (d) => (
-                          hasHollowCircles ? hollowColor : nameColorMap[d.name]
-                      ))
                       .style('cursor', 'pointer');
             }
         }

--- a/test/specs/brush.spec.js
+++ b/test/specs/brush.spec.js
@@ -58,7 +58,7 @@ define(['jquery', 'd3', 'brush', 'brushChartDataBuilder'], function($, d3, chart
         });
 
         describe('when margins are set partially', function() {
-            
+
             it('should override the default values', () => {
                 let previous = brushChart.margin(),
                 expected = {
@@ -74,7 +74,7 @@ define(['jquery', 'd3', 'brush', 'brushChartDataBuilder'], function($, d3, chart
                 expect(previous).not.toBe(actual);
                 expect(actual).toEqual(expected);
             })
-        });  
+        });
 
         describe('the API', function() {
 

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -195,6 +195,18 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
                 expect(actual).toBe(expected);
             });
 
+            it('should provide xAxisFormat getter and setter', () => {
+                let previous = scatterPlot.xAxisFormat(),
+                    expected = '$',
+                    actual;
+
+                scatterPlot.xAxisFormat(expected);
+                actual = scatterPlot.xAxisFormat();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
             it('should provide xAxisLabelOffset getter and setter', () => {
                 let previous = scatterPlot.xAxisLabelOffset(),
                     expected = 40,
@@ -226,6 +238,18 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
 
                 scatterPlot.yAxisLabel(expected);
                 actual = scatterPlot.yAxisLabel();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
+            it('should provide yAxisFormat getter and setter', () => {
+                let previous = scatterPlot.yAxisFormat(),
+                    expected = '$',
+                    actual;
+
+                scatterPlot.yAxisFormat(expected);
+                actual = scatterPlot.yAxisFormat();
 
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -355,6 +355,41 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
             });
         });
 
+        describe('when formats of the axis values are set', () => {
+
+            it('should have correct x-axis values format', () => {
+                let format = '$';
+                let previous = scatterPlot.xAxisFormat();
+                let expected = '$100';
+
+                scatterPlot.xAxisFormat(format);
+                containerFixture.datum(dataset).call(scatterPlot);
+
+                let actual = containerFixture.select('svg')
+                    .selectAll('.x-axis-group .tick text')
+                    .text();
+
+                expect(previous).not.toBe(actual);
+                expect(actual).toBe(expected);
+            });
+
+            it('should have correct y-axis values format', () => {
+                let format = '$';
+                let previous = scatterPlot.yAxisFormat();
+                let expected = '$50';
+
+                scatterPlot.yAxisFormat(format);
+                containerFixture.datum(dataset).call(scatterPlot);
+
+                let actual = containerFixture.select('svg')
+                    .selectAll('.y-axis-group .tick:nth-child(3) text')
+                    .text();
+
+                expect(previous).not.toBe(actual);
+                expect(actual).toBe(expected);
+            });
+        });
+
         describe('when axis labels are set', () => {
             let scatterPlot, dataset, containerFixture, f;
 

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -292,6 +292,51 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
             });
         });
 
+        describe('Plot data points(circles)', () => {
+
+            /**
+             * With animation, the chart is initialized without
+             * points. In order to render data points in tests,
+             * animations should be turned off.
+             */
+            beforeEach(() => {
+                dataset = buildDataSet('withOneSource');
+                scatterPlot = chart()
+                    .isAnimated(false);
+
+                // DOM Fixture Setup
+                f = jasmine.getFixtures();
+                f.fixturesPath = 'base/test/fixtures/';
+                f.load('testContainer.html');
+
+                containerFixture = d3.select('.test-container');
+                containerFixture.datum(dataset).call(scatterPlot);
+            });
+
+            afterEach(() => {
+                containerFixture.remove();
+                f = jasmine.getFixtures();
+                f.cleanUp();
+                f.clearCache();
+            });
+
+            it('should have proper default parameteres', () => {
+                scatterPlot.isAnimated(false);
+                containerFixture.datum(dataset).call(scatterPlot);
+
+                let circles = containerFixture.selectAll('.chart-group circle').nodes();
+
+                circles.forEach((circle) => {
+                    expect(circle).toHaveAttr('class', 'data-point-highlighter');
+                    expect(circle).toHaveAttr('fill-opacity', '0.24');
+                    expect(circle).toHaveAttr('fill');
+                    expect(circle).toHaveAttr('cx');
+                    expect(circle).toHaveAttr('cy');
+                    expect(circle).toHaveAttr('style');
+                });
+            });
+        });
+
         describe('Aspect Ratio', () => {
 
             describe('when an aspect ratio is set', function () {


### PR DESCRIPTION
More improvements for Scatter Plot

## Description
* Added 0.24 opacity, noted by Sun that it's used in Stacked Area and other charts.
* `circleOpacity` sets `fill-opacity` rather than `opacity`. The outline color should be solid -- this follows Sun's notes as well
* Added tests for data points
* added `xAxisFormat` and `yAxisFormat` chart API methods for formatting x and y axis values
* Used correct class for both axis labels
* Added DOM tests for the new API functions

## Motivation and Context
Improvements and essential API methods

## How Has This Been Tested?
Added multiple tests to `scatter-plot.spec.js`
* Added tests for data points
* Added DOM tests for the new API functions

## Screenshots (if appropriate):
* Circle opacity default is 0.24 and stroke (outline) color is solid:

![screen shot 2018-03-30 at 12 47 00 am](https://user-images.githubusercontent.com/31934144/38129456-f91609ac-33b3-11e8-8712-7b1d6b207f6a.png)

![screen shot 2018-03-30 at 12 47 04 am](https://user-images.githubusercontent.com/31934144/38129458-fbb5cf62-33b3-11e8-8be5-17c8c1ce844b.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
