### PR TITLE
Feature - scatter plot data point value highlighter

### DIFF
--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -54,6 +54,7 @@ scatterPlotContainer
                 <pre><code class="language-javascript">
 scatterChart
     .width(containerWidth)
+    .hasHighlightedValues(true)
     .hasHollowCircles(true)
     .margin({
         left: 60,

--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -54,7 +54,7 @@ scatterPlotContainer
                 <pre><code class="language-javascript">
 scatterChart
     .width(containerWidth)
-    .hasHighlightedValues(true)
+    .hasCrossHairs(true)
     .hasHollowCircles(true)
     .margin({
         left: 60,

--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -55,6 +55,10 @@ scatterPlotContainer
 scatterChart
     .width(containerWidth)
     .hasHollowCircles(true)
+    .margin({
+        left: 60,
+        bottom: 45
+    })
     .maxCircleArea(15);
 
 container

--- a/demos/src/demo-scatter-plot.js
+++ b/demos/src/demo-scatter-plot.js
@@ -69,6 +69,10 @@ function createScatterPlotWithIncreasedAreaAndHollowCircles() {
         scatterChart
             .width(containerWidth)
             .hasHollowCircles(true)
+            .margin({
+                left: 60,
+                bottom: 45
+            })
             .maxCircleArea(15);
 
         scatterPlotContainer.datum(dataset).call(scatterChart);

--- a/demos/src/demo-scatter-plot.js
+++ b/demos/src/demo-scatter-plot.js
@@ -68,7 +68,7 @@ function createScatterPlotWithIncreasedAreaAndHollowCircles() {
 
         scatterChart
             .width(containerWidth)
-            .hasHighlightedValues(true)
+            .hasCrossHairs(true)
             .hasHollowCircles(true)
             .margin({
                 left: 60,

--- a/demos/src/demo-scatter-plot.js
+++ b/demos/src/demo-scatter-plot.js
@@ -68,6 +68,7 @@ function createScatterPlotWithIncreasedAreaAndHollowCircles() {
 
         scatterChart
             .width(containerWidth)
+            .hasHighlightedValues(true)
             .hasHollowCircles(true)
             .margin({
                 left: 60,

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -757,7 +757,7 @@ define(function(require) {
         /**
          * Gets or Sets the colorSchema of the chart
          * @param  {String[]} _x            Desired colorSchema for the chart
-         * @return {colorSchema | module}   Current colorSchema or Chart module to chain calls
+         * @return {String[] | module}   Current colorSchema or Chart module to chain calls
          * @public
          * @example
          * scatterPlot.colorSchema(['#fff', '#bbb', '#ccc'])
@@ -834,7 +834,7 @@ define(function(require) {
         /**
          * Gets or Sets the height of the chart
          * @param  {Number} _x          Desired height for the chart
-         * @return {height | module}    Current height or Chart module to chain calls
+         * @return {Number | module}    Current height or Chart module to chain calls
          * @public
          */
         exports.height = function (_x) {
@@ -887,7 +887,7 @@ define(function(require) {
         /**
          * Gets or Sets the margin object of the chart
          * @param  {Object} _x          Desired margin object properties for each side
-         * @return {margin | module}    Current margin or Chart module to chain calls
+         * @return {Object | module}    Current margin or Chart module to chain calls
          * @public
          */
         exports.margin = function(_x) {
@@ -999,7 +999,7 @@ define(function(require) {
         /**
          * Gets or Sets the xTicks of the chart
          * @param  {Number} _x         Desired height for the chart
-         * @return {xTicks | module}   Current xTicks or Chart module to chain calls
+         * @return {Number | module}   Current xTicks or Chart module to chain calls
          * @public
          */
         exports.xTicks = function(_x) {
@@ -1014,7 +1014,7 @@ define(function(require) {
         /**
          * Exposes ability to set the format of y-axis values
          * @param  {String} _x               Desired height for the chart
-         * @return {yAxisFormat | module}    Current yAxisFormat or Chart module to chain calls
+         * @return {String | module}    Current yAxisFormat or Chart module to chain calls
          * @public
          */
         exports.yAxisFormat = function(_x) {
@@ -1029,7 +1029,7 @@ define(function(require) {
         /**
          * Gets or Sets the y-axis label of the chart
          * @param  {String} _x Desired label string
-         * @return {yAxisLabel | module} Current yAxisLabel or Chart module to chain calls
+         * @return {String | module} Current yAxisLabel or Chart module to chain calls
          * @public
          * @example scatterPlot.yAxisLabel('Ice Cream Consmuption Growth')
          */

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -420,11 +420,11 @@ define(function(require) {
                 .data(yScale.ticks(xTicks))
                 .enter()
                  .append('line')
-                .attr('class', 'vertical-grid-line')
-                .attr('y1', (xAxisPadding.left))
-                .attr('y2', chartHeight)
-                .attr('x1', (d) => xScale(d))
-                .attr('x2', (d) => xScale(d));
+                  .attr('class', 'vertical-grid-line')
+                  .attr('y1', (xAxisPadding.left))
+                  .attr('y2', chartHeight)
+                  .attr('x1', (d) => xScale(d))
+                  .attr('x2', (d) => xScale(d));
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -129,6 +129,7 @@ define(function(require) {
         highlightFilterId,
         highlightStrokeWidth = 10,
         highlightContainer,
+        highlightTextLegendOffset = -45,
 
         xAxisPadding = {
             top: 0,
@@ -497,7 +498,7 @@ define(function(require) {
                 .append('line')
                   .attr('stroke', (d) => nameColorMap[d.name])
                   .attr('class', 'highlight-y-line')
-                  .attr('x1', (d) => xScale(d.x))
+                  .attr('x1', (d) => (xScale(d.x) - areaScale(d.y)))
                   .attr('x2', (d) => 0)
                   .attr('y1', (d) => yScale(d.y))
                   .attr('y2', (d) => yScale(d.y));
@@ -512,8 +513,32 @@ define(function(require) {
                   .attr('class', 'highlight-x-line')
                   .attr('x1', (d) => xScale(d.x))
                   .attr('x2', (d) => xScale(d.x))
-                  .attr('y1', (d) => yScale(d.y))
+                  .attr('y1', (d) => (yScale(d.y) + areaScale(d.y)))
                   .attr('y2', (d) => chartHeight);
+
+            // Draw data label for y value
+            highlightContainer.selectAll('text.highlight-y-legend')
+                .data([data])
+                .enter()
+                .append('text')
+                  .attr('text-anchor', 'middle')
+                  .attr('fill', (d) => nameColorMap[d.name])
+                  .attr('class', 'highlight-y-legend')
+                  .attr('y', (d) => (yScale(d.y) + (areaScale(d.y) / 2)))
+                  .attr('x', highlightTextLegendOffset)
+                  .text((d) => `${d.y}`);
+
+            // Draw data label for x value
+            highlightContainer.selectAll('text.highlight-x-legend')
+                .data([data])
+                .enter()
+                .append('text')
+                  .attr('text-anchor', 'middle')
+                  .attr('fill', (d) => nameColorMap[d.name])
+                  .attr('class', 'highlight-x-legend')
+                  .attr('transform', `translate(0, ${chartHeight - highlightTextLegendOffset})`)
+                  .attr('x', (d) => (xScale(d.x) - (areaScale(d.y) / 2)))
+                  .text((d) => `${d.x}`);
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -128,6 +128,7 @@ define(function(require) {
         highlightFilter,
         highlightFilterId,
         highlightStrokeWidth = 10,
+        highlightContainer,
 
         xAxisPadding = {
             top: 0,
@@ -406,17 +407,17 @@ define(function(require) {
         }
 
         /**
- * Draws vertical gridlines of the chart
- * These gridlines are parallel to y-axis
- * @return {void}
- * @private
- */
+         * Draws vertical gridlines of the chart
+         * These gridlines are parallel to y-axis
+         * @return {void}
+         * @private
+         */
         function drawVerticalGridLines() {
             maskGridLines = svg.select('.grid-lines-group')
                 .selectAll('line.vertical-grid-line')
                 .data(yScale.ticks(xTicks))
                 .enter()
-                .append('line')
+                 .append('line')
                 .attr('class', 'vertical-grid-line')
                 .attr('y1', (xAxisPadding.left))
                 .attr('y2', chartHeight)
@@ -474,6 +475,45 @@ define(function(require) {
                     .attr('cy', (d) => yScale(d.y))
                     .style('cursor', 'pointer');
             }
+        }
+
+        /**
+         * Draws lines and labels for data point values
+         * @private
+        */
+        function drawDataPointsValueHighlights(data) {
+            if (highlightContainer) {
+                svg.selectAll('.data-point-value-highlight').remove();
+            }
+
+            highlightContainer = svg.select('.metadata-group')
+                .append('g')
+                .classed('data-point-value-highlight', true);
+
+            // Draw line perpendicular to y-axis
+            highlightContainer.selectAll('line.highlight-y-line')
+                .data([data])
+                .enter()
+                .append('line')
+                  .attr('stroke', (d) => nameColorMap[d.name])
+                  .attr('class', 'highlight-y-line')
+                  .attr('x1', (d) => xScale(d.x))
+                  .attr('x2', (d) => 0)
+                  .attr('y1', (d) => yScale(d.y))
+                  .attr('y2', (d) => yScale(d.y));
+
+
+            // Draw line perpendicular to x-axis
+            highlightContainer.selectAll('line.highlight-x-line')
+                .data([data])
+                .enter()
+                .append('line')
+                  .attr('stroke', (d) => nameColorMap[d.name])
+                  .attr('class', 'highlight-x-line')
+                  .attr('x1', (d) => xScale(d.x))
+                  .attr('x2', (d) => xScale(d.x))
+                  .attr('y1', (d) => yScale(d.y))
+                  .attr('y2', (d) => chartHeight);
         }
 
         /**
@@ -621,8 +661,11 @@ define(function(require) {
                     .style('stroke-width', highlightStrokeWidth)
                     .style('stroke-opacity', highlightCircleOpacity);
 
+            // apply glow container overlay
             highlightCircle
                 .attr('filter', `url(#${highlightFilterId})`);
+
+            drawDataPointsValueHighlights(data);
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -528,7 +528,7 @@ define(function(require) {
                   .attr('class', 'highlight-y-legend')
                   .attr('y', (d) => (yScale(d.y) + (areaScale(d.y) / 2)))
                   .attr('x', highlightTextLegendOffset)
-                  .text((d) => `${d.y}`);
+                  .text((d) => `${d3Format.format(yAxisFormat)(d.y)}`);
 
             // Draw data label for x value
             highlightContainer.selectAll('text.highlight-x-legend')
@@ -540,7 +540,7 @@ define(function(require) {
                   .attr('class', 'highlight-x-legend')
                   .attr('transform', `translate(0, ${chartHeight - highlightTextLegendOffset})`)
                   .attr('x', (d) => (xScale(d.x) - (areaScale(d.y) / 2)))
-                  .text((d) => `${d.x}`);
+                  .text((d) => `${d3Format.format(xAxisFormat)(d.x)}`);
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -146,6 +146,7 @@ define(function(require) {
         colorSchema = colorHelper.colorSchemas.britecharts,
 
         isAnimated = true,
+        hasHighlightedValues = false,
         ease = d3Ease.easeCircleIn,
         delay = 500,
         duration = 500,
@@ -692,7 +693,9 @@ define(function(require) {
             highlightCircle
                 .attr('filter', `url(#${highlightFilterId})`);
 
-            drawDataPointsValueHighlights(data);
+            if (hasHighlightedValues) {
+                drawDataPointsValueHighlights(data);
+            }
         }
 
         /**
@@ -736,7 +739,7 @@ define(function(require) {
          * Use this to set opacity of a circle for each data point of the chart.
          * It makes the area of each data point more transparent if it's less than 1.
          * @param  {Number} _x=0.24            Desired opacity of circles of the chart
-         * @return {circleOpacity | module}    Current circleOpacity or Scatter Chart module to chain calls
+         * @return {circleOpacity | module}    Current circleOpacity or Chart module to chain calls
          * @public
          * @example
          * scatterPlot.circleOpacity(0.6)
@@ -782,7 +785,7 @@ define(function(require) {
          * Gets or Sets the grid mode.
          *
          * @param  {String} _x Desired mode for the grid ('vertical'|'horizontal'|'full')
-         * @return {String | module} Current mode of the grid or Area Chart module to chain calls
+         * @return {String | module} Current mode of the grid or Chart module to chain calls
          * @public
          */
         exports.grid = function (_x) {
@@ -795,9 +798,28 @@ define(function(require) {
         };
 
         /**
+         * Gets or Sets the hasHighlightedValues status. If true,
+         * the hovered data point will be highlighted with lines
+         * and legend from both x and y axis. The user will see
+         * values for x under x axis line and y under y axis. Lines
+         * will be drawn with respect to highlighted data point
+         * @param  {boolean} _x=false               Desired hasHighlightedValues status for chart
+         * @return {hasHighlightedValues | module}  Current hasHighlightedValues or Chart module to chain calls
+         * @public
+         */
+        exports.hasHighlightedValues = function(_x) {
+            if (!arguments.length) {
+                return hasHighlightedValues;
+            }
+            hasHighlightedValues = _x;
+
+            return this;
+        }
+
+        /**
          * Gets or Sets the hasHollowCircles value of the chart area
          * @param  {boolean} _x=false             Choose whether chart's data points/circles should be hollow
-         * @return {hasHollowCircles | module}    Current hasHollowCircles value or Scatter Chart module to chain calls
+         * @return {hasHollowCircles | module}    Current hasHollowCircles value or Chart module to chain calls
          * @public
          */
         exports.hasHollowCircles = function (_x) {
@@ -812,7 +834,7 @@ define(function(require) {
         /**
          * Gets or Sets the height of the chart
          * @param  {Number} _x          Desired height for the chart
-         * @return {height | module}    Current height or Scatter Chart module to chain calls
+         * @return {height | module}    Current height or Chart module to chain calls
          * @public
          */
         exports.height = function (_x) {
@@ -828,10 +850,29 @@ define(function(require) {
         };
 
         /**
+         * Sets a custom distance between legend
+         * values with respect to both axises. The legends
+         * show up when hasHighlightedValues is true.
+         * @param  {Number} _x          Desired height for the chart
+         * @return {height | module}    Current height or Chart module to chain calls
+         * @public
+         * @example
+         * scatterPlot.highlightTextLegendOffset(-55)
+         */
+        exports.highlightTextLegendOffset = function(_x) {
+            if (!arguments.length) {
+                return highlightTextLegendOffset;
+            }
+            highlightTextLegendOffset = _x;
+
+            return this;
+        }
+
+        /**
          * Gets or Sets isAnimated value. If set to true,
          * the chart will be initialized or updated with animation.
          * @param  {boolean} _x=false       Desired margin object properties for each side
-         * @return {isAnimated | module}    Current height or Scatter Chart module to chain calls
+         * @return {isAnimated | module}    Current height or Chart module to chain calls
          * @public
          */
         exports.isAnimated = function(_x) {
@@ -846,7 +887,7 @@ define(function(require) {
         /**
          * Gets or Sets the margin object of the chart
          * @param  {Object} _x          Desired margin object properties for each side
-         * @return {margin | module}    Current height or Scatter Chart module to chain calls
+         * @return {margin | module}    Current height or Chart module to chain calls
          * @public
          */
         exports.margin = function(_x) {
@@ -864,7 +905,7 @@ define(function(require) {
         /**
          * Gets or Sets the maximum value of the chart area
          * @param  {Number} _x=10       Desired margin object properties for each side
-         * @return {maxCircleArea | module}    Current height or Scatter Chart module to chain calls
+         * @return {maxCircleArea | module}    Current height or Chart module to chain calls
          * @public
          */
         exports.maxCircleArea = function(_x) {
@@ -892,7 +933,7 @@ define(function(require) {
         /**
          * Gets or Sets the height of the chart
          * @param  {Number} _x          Desired height for the chart
-         * @return {width | module}    Current width or Scatter Chart module to chain calls
+         * @return {width | module}    Current width or Chart module to chain calls
          * @public
          */
         exports.width = function(_x) {
@@ -911,7 +952,7 @@ define(function(require) {
          * Gets or Sets the xAxisLabel of the chart. Adds a
          * label bellow x-axis for better clarify of data representation.
          * @param  {String} _x              Desired string for x-axis label of the chart
-         * @return {xAxisLabel | module}    Current width or Scatter Chart module to chain calls
+         * @return {xAxisLabel | module}    Current width or Chart module to chain calls
          * @public
          */
         exports.xAxisLabel = function(_x) {
@@ -943,7 +984,7 @@ define(function(require) {
         /**
          * Exposes ability to set the format of x-axis values
          * @param  {String} _x               Desired height for the chart
-         * @return {yAxisFormat | module}    Current width or Scatter Chart module to chain calls
+         * @return {yAxisFormat | module}    Current width or Chart module to chain calls
          * @public
          */
         exports.xAxisFormat = function (_x) {
@@ -958,7 +999,7 @@ define(function(require) {
         /**
          * Gets or Sets the xTicks of the chart
          * @param  {Number} _x         Desired height for the chart
-         * @return {xTicks | module}    Current width or Scatter Chart module to chain calls
+         * @return {xTicks | module}    Current width or Chart module to chain calls
          * @public
          */
         exports.xTicks = function(_x) {
@@ -973,7 +1014,7 @@ define(function(require) {
         /**
          * Exposes ability to set the format of y-axis values
          * @param  {String} _x               Desired height for the chart
-         * @return {yAxisFormat | module}    Current width or Scatter Chart module to chain calls
+         * @return {yAxisFormat | module}    Current width or Chart module to chain calls
          * @public
          */
         exports.yAxisFormat = function(_x) {
@@ -1021,7 +1062,7 @@ define(function(require) {
         /**
          * Gets or Sets the xTicks of the chart
          * @param  {Number} _x         Desired height for the chart
-         * @return {xTicks | module}    Current width or Scatter Chart module to chain calls
+         * @return {xTicks | module}    Current width or Chart module to chain calls
          * @public
          */
         exports.yTicks = function(_x) {

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -146,7 +146,7 @@ define(function(require) {
         colorSchema = colorHelper.colorSchemas.britecharts,
 
         isAnimated = true,
-        hasHighlightedValues = false,
+        hasCrossHairs = false,
         ease = d3Ease.easeCircleIn,
         delay = 500,
         duration = 500,
@@ -498,7 +498,7 @@ define(function(require) {
                 .data([data])
                 .enter()
                 .append('line')
-                  .attr('stroke', (d) => nameColorMap[d.name])
+                  .attr('stroke', ({name}) => nameColorMap[name])
                   .attr('class', 'highlight-y-line')
                   .attr('x1', (d) => (xScale(d.x) - areaScale(d.y)))
                   .attr('x2', (d) => 0)
@@ -511,7 +511,7 @@ define(function(require) {
                 .data([data])
                 .enter()
                 .append('line')
-                  .attr('stroke', (d) => nameColorMap[d.name])
+                  .attr('stroke', ({name}) => nameColorMap[name])
                   .attr('class', 'highlight-x-line')
                   .attr('x1', (d) => xScale(d.x))
                   .attr('x2', (d) => xScale(d.x))
@@ -524,7 +524,7 @@ define(function(require) {
                 .enter()
                 .append('text')
                   .attr('text-anchor', 'middle')
-                  .attr('fill', (d) => nameColorMap[d.name])
+                  .attr('fill', ({name}) => nameColorMap[name])
                   .attr('class', 'highlight-y-legend')
                   .attr('y', (d) => (yScale(d.y) + (areaScale(d.y) / 2)))
                   .attr('x', highlightTextLegendOffset)
@@ -536,7 +536,7 @@ define(function(require) {
                 .enter()
                 .append('text')
                   .attr('text-anchor', 'middle')
-                  .attr('fill', (d) => nameColorMap[d.name])
+                  .attr('fill', ({name}) => nameColorMap[name])
                   .attr('class', 'highlight-x-legend')
                   .attr('transform', `translate(0, ${chartHeight - highlightTextLegendOffset})`)
                   .attr('x', (d) => (xScale(d.x) - (areaScale(d.y) / 2)))
@@ -693,7 +693,7 @@ define(function(require) {
             highlightCircle
                 .attr('filter', `url(#${highlightFilterId})`);
 
-            if (hasHighlightedValues) {
+            if (hasCrossHairs) {
                 drawDataPointsValueHighlights(data);
             }
         }
@@ -798,20 +798,20 @@ define(function(require) {
         };
 
         /**
-         * Gets or Sets the hasHighlightedValues status. If true,
+         * Gets or Sets the hasCrossHairs status. If true,
          * the hovered data point will be highlighted with lines
          * and legend from both x and y axis. The user will see
          * values for x under x axis line and y under y axis. Lines
          * will be drawn with respect to highlighted data point
-         * @param  {boolean} _x=false               Desired hasHighlightedValues status for chart
-         * @return {boolean | module}  Current hasHighlightedValues or Chart module to chain calls
+         * @param  {boolean} _x=false               Desired hasCrossHairs status for chart
+         * @return {boolean | module}  Current hasCrossHairs or Chart module to chain calls
          * @public
          */
-        exports.hasHighlightedValues = function(_x) {
+        exports.hasCrossHairs = function(_x) {
             if (!arguments.length) {
-                return hasHighlightedValues;
+                return hasCrossHairs;
             }
-            hasHighlightedValues = _x;
+            hasCrossHairs = _x;
 
             return this;
         }
@@ -852,7 +852,7 @@ define(function(require) {
         /**
          * Sets a custom distance between legend
          * values with respect to both axises. The legends
-         * show up when hasHighlightedValues is true.
+         * show up when hasCrossHairs is true.
          * @param  {Number} _x          Desired highlightTextLegendOffset for the chart
          * @return {Number | module}    Current highlightTextLegendOffset or Chart module to chain calls
          * @public

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -479,12 +479,13 @@ define(function(require) {
         }
 
         /**
-         * Draws lines and labels for data point values
+         * Draws lines and labels for the
+         * highlighted data point value
          * @private
         */
         function drawDataPointsValueHighlights(data) {
             if (highlightContainer) {
-                svg.selectAll('.data-point-value-highlight').remove();
+                removeDataPointsValueHighlights();
             }
 
             highlightContainer = svg.select('.metadata-group')
@@ -543,7 +544,7 @@ define(function(require) {
 
         /**
          * Draws grid lines on the background of the chart
-         * @return void
+         * @return {void}
          * @private
          */
         function drawGridLines() {
@@ -646,6 +647,7 @@ define(function(require) {
          */
         function handleMouseOut(e, d) {
             removePointHighlight();
+            removeDataPointsValueHighlights();
             dispatcher.call('customMouseOut', e, d, d3Selection.mouse(e));
         }
 
@@ -700,6 +702,16 @@ define(function(require) {
          */
         function removePointHighlight() {
             svg.selectAll('circle.highlight-circle').remove();
+        }
+
+        /**
+         * Removes the lines and labels for the
+         * highlighted data point value
+         * @return {void}
+         * @private
+         */
+        function removeDataPointsValueHighlights() {
+            svg.selectAll('.data-point-value-highlight').remove();
         }
 
         // API

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -984,7 +984,7 @@ define(function(require) {
         /**
          * Exposes ability to set the format of x-axis values
          * @param  {String} _x               Desired height for the chart
-         * @return {yAxisFormat | module}    Current xAxisFormat or Chart module to chain calls
+         * @return {String | module}         Current xAxisFormat or Chart module to chain calls
          * @public
          */
         exports.xAxisFormat = function (_x) {

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -406,6 +406,77 @@ define(function(require) {
         }
 
         /**
+ * Draws vertical gridlines of the chart
+ * These gridlines are parallel to y-axis
+ * @return {void}
+ * @private
+ */
+        function drawVerticalGridLines() {
+            maskGridLines = svg.select('.grid-lines-group')
+                .selectAll('line.vertical-grid-line')
+                .data(yScale.ticks(xTicks))
+                .enter()
+                .append('line')
+                .attr('class', 'vertical-grid-line')
+                .attr('y1', (xAxisPadding.left))
+                .attr('y2', chartHeight)
+                .attr('x1', (d) => xScale(d))
+                .attr('x2', (d) => xScale(d));
+        }
+
+        /**
+         * Draws the points for each data element
+         * on the chart group
+         * @private
+        */
+        function drawDataPoints() {
+            let circles = svg.select('.chart-group')
+                .selectAll('circle')
+                .data(dataPoints)
+                .enter();
+
+            if (isAnimated) {
+                circles
+                    .append('circle')
+                    .on('click', function (d) {
+                        handleClick(this, d, chartWidth, chartHeight);
+                    })
+                    .transition()
+                    .delay(delay)
+                    .duration(duration)
+                    .ease(ease)
+                    .attr('class', 'point')
+                    .attr('class', 'data-point-highlighter')
+                    .style('stroke', (d) => nameColorMap[d.name])
+                    .attr('fill', (d) => (
+                        hasHollowCircles ? hollowColor : nameColorMap[d.name]
+                    ))
+                    .attr('fill-opacity', circleOpacity)
+                    .attr('r', (d) => areaScale(d.y))
+                    .attr('cx', (d) => xScale(d.x))
+                    .attr('cy', (d) => yScale(d.y))
+                    .style('cursor', 'pointer');
+            } else {
+                circles
+                    .append('circle')
+                    .on('click', function (d) {
+                        handleClick(this, d, chartWidth, chartHeight);
+                    })
+                    .attr('class', 'point')
+                    .attr('class', 'data-point-highlighter')
+                    .style('stroke', (d) => nameColorMap[d.name])
+                    .attr('fill', (d) => (
+                        hasHollowCircles ? hollowColor : nameColorMap[d.name]
+                    ))
+                    .attr('fill-opacity', circleOpacity)
+                    .attr('r', (d) => areaScale(d.y))
+                    .attr('cx', (d) => xScale(d.x))
+                    .attr('cy', (d) => yScale(d.y))
+                    .style('cursor', 'pointer');
+            }
+        }
+
+        /**
          * Draws grid lines on the background of the chart
          * @return void
          * @private
@@ -461,77 +532,6 @@ define(function(require) {
                     .attr('x2', chartWidth)
                     .attr('y1', (d) => yScale(d))
                     .attr('y2', (d) => yScale(d))
-        }
-
-        /**
-         * Draws vertical gridlines of the chart
-         * These gridlines are parallel to y-axis
-         * @return {void}
-         * @private
-         */
-        function drawVerticalGridLines() {
-            maskGridLines = svg.select('.grid-lines-group')
-                .selectAll('line.vertical-grid-line')
-                .data(yScale.ticks(xTicks))
-                .enter()
-                  .append('line')
-                    .attr('class', 'vertical-grid-line')
-                    .attr('y1', (xAxisPadding.left))
-                    .attr('y2', chartHeight)
-                    .attr('x1', (d) => xScale(d))
-                    .attr('x2', (d) => xScale(d));
-        }
-
-        /**
-         * Draws the points for each data element
-         * on the chart group
-         * @private
-        */
-        function drawDataPoints() {
-            let circles = svg.select('.chart-group')
-                .selectAll('circle')
-                .data(dataPoints)
-                .enter();
-
-            if (isAnimated) {
-                circles
-                  .append('circle')
-                    .on('click', function (d) {
-                        handleClick(this, d, chartWidth, chartHeight);
-                    })
-                    .transition()
-                    .delay(delay)
-                    .duration(duration)
-                    .ease(ease)
-                    .attr('class', 'point')
-                    .attr('class', 'data-point-highlighter')
-                    .style('stroke', (d) => nameColorMap[d.name])
-                    .attr('fill', (d) => (
-                        hasHollowCircles ? hollowColor : nameColorMap[d.name]
-                    ))
-                    .attr('fill-opacity', circleOpacity)
-                    .attr('r', (d) => areaScale(d.y))
-                    .attr('cx', (d) => xScale(d.x))
-                    .attr('cy', (d) => yScale(d.y))
-                    .style('cursor', 'pointer');
-            } else {
-                circles
-                    .append('circle')
-                      .on('click', function (d) {
-                          handleClick(this, d, chartWidth, chartHeight);
-                      })
-                      .attr('class', 'point')
-                      .attr('class', 'data-point-highlighter')
-                      .style('stroke', (d) => nameColorMap[d.name])
-                      .attr('fill', (d) => (
-                        hasHollowCircles ? hollowColor : nameColorMap[d.name]
-                      ))
-                      .attr('fill-opacity', circleOpacity)
-                      .attr('r', (d) => areaScale(d.y))
-                      .attr('cx', (d) => xScale(d.x))
-                      .attr('cy', (d) => yScale(d.y))
-                      .style('cursor', 'pointer');
-            }
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -722,7 +722,7 @@ define(function(require) {
         /**
          * Gets or Sets the aspect ratio of the chart
          * @param  {Number} _x            Desired aspect ratio for the graph
-         * @return {aspectRatio | module} Current aspect ratio or Chart module to chain calls
+         * @return {Number | module} Current aspect ratio or Chart module to chain calls
          * @public
          */
         exports.aspectRatio = function (_x) {
@@ -739,7 +739,7 @@ define(function(require) {
          * Use this to set opacity of a circle for each data point of the chart.
          * It makes the area of each data point more transparent if it's less than 1.
          * @param  {Number} _x=0.24            Desired opacity of circles of the chart
-         * @return {circleOpacity | module}    Current circleOpacity or Chart module to chain calls
+         * @return {Number | module}    Current circleOpacity or Chart module to chain calls
          * @public
          * @example
          * scatterPlot.circleOpacity(0.6)
@@ -784,8 +784,8 @@ define(function(require) {
         /**
          * Gets or Sets the grid mode.
          *
-         * @param  {String} _x Desired mode for the grid ('vertical'|'horizontal'|'full')
-         * @return {String | module} Current mode of the grid or Chart module to chain calls
+         * @param  {String} _x          Desired mode for the grid ('vertical'|'horizontal'|'full')
+         * @return {String | module}    Current mode of the grid or Chart module to chain calls
          * @public
          */
         exports.grid = function (_x) {
@@ -804,7 +804,7 @@ define(function(require) {
          * values for x under x axis line and y under y axis. Lines
          * will be drawn with respect to highlighted data point
          * @param  {boolean} _x=false               Desired hasHighlightedValues status for chart
-         * @return {hasHighlightedValues | module}  Current hasHighlightedValues or Chart module to chain calls
+         * @return {boolean | module}  Current hasHighlightedValues or Chart module to chain calls
          * @public
          */
         exports.hasHighlightedValues = function(_x) {
@@ -819,7 +819,7 @@ define(function(require) {
         /**
          * Gets or Sets the hasHollowCircles value of the chart area
          * @param  {boolean} _x=false             Choose whether chart's data points/circles should be hollow
-         * @return {hasHollowCircles | module}    Current hasHollowCircles value or Chart module to chain calls
+         * @return {boolean | module}    Current hasHollowCircles value or Chart module to chain calls
          * @public
          */
         exports.hasHollowCircles = function (_x) {
@@ -853,8 +853,8 @@ define(function(require) {
          * Sets a custom distance between legend
          * values with respect to both axises. The legends
          * show up when hasHighlightedValues is true.
-         * @param  {Number} _x          Desired height for the chart
-         * @return {height | module}    Current height or Chart module to chain calls
+         * @param  {Number} _x          Desired highlightTextLegendOffset for the chart
+         * @return {Number | module}    Current highlightTextLegendOffset or Chart module to chain calls
          * @public
          * @example
          * scatterPlot.highlightTextLegendOffset(-55)
@@ -871,8 +871,8 @@ define(function(require) {
         /**
          * Gets or Sets isAnimated value. If set to true,
          * the chart will be initialized or updated with animation.
-         * @param  {boolean} _x=false       Desired margin object properties for each side
-         * @return {isAnimated | module}    Current height or Chart module to chain calls
+         * @param  {boolean} _x=false       Desired isAnimated properties for each side
+         * @return {boolean | module}    Current isAnimated or Chart module to chain calls
          * @public
          */
         exports.isAnimated = function(_x) {
@@ -887,7 +887,7 @@ define(function(require) {
         /**
          * Gets or Sets the margin object of the chart
          * @param  {Object} _x          Desired margin object properties for each side
-         * @return {margin | module}    Current height or Chart module to chain calls
+         * @return {margin | module}    Current margin or Chart module to chain calls
          * @public
          */
         exports.margin = function(_x) {
@@ -904,8 +904,8 @@ define(function(require) {
 
         /**
          * Gets or Sets the maximum value of the chart area
-         * @param  {Number} _x=10       Desired margin object properties for each side
-         * @return {maxCircleArea | module}    Current height or Chart module to chain calls
+         * @param  {Number} _x=10              Desired margin object properties for each side
+         * @return {Number | module}    Current maxCircleArea or Chart module to chain calls
          * @public
          */
         exports.maxCircleArea = function(_x) {
@@ -932,8 +932,8 @@ define(function(require) {
 
         /**
          * Gets or Sets the height of the chart
-         * @param  {Number} _x          Desired height for the chart
-         * @return {width | module}    Current width or Chart module to chain calls
+         * @param  {Number} _x           Desired height for the chart
+         * @return {Number | module}     Current width or Chart module to chain calls
          * @public
          */
         exports.width = function(_x) {
@@ -952,7 +952,7 @@ define(function(require) {
          * Gets or Sets the xAxisLabel of the chart. Adds a
          * label bellow x-axis for better clarify of data representation.
          * @param  {String} _x              Desired string for x-axis label of the chart
-         * @return {xAxisLabel | module}    Current width or Chart module to chain calls
+         * @return {String | module}        Current xAxisLabel or Chart module to chain calls
          * @public
          */
         exports.xAxisLabel = function(_x) {
@@ -967,8 +967,8 @@ define(function(require) {
         /**
          * Gets or Sets the offset of the xAxisLabel of the chart.
          * The method accepts both positive and negative values.
-         * @param  {Number} _x=-40                Desired offset for the label
-         * @return {xAxisLabelOffset | module}    Current xAxisLabelOffset or Chart module to chain calls
+         * @param  {Number} _x=-40          Desired offset for the label
+         * @return {Number | module}        Current xAxisLabelOffset or Chart module to chain calls
          * @public
          * @example scatterPlot.xAxisLabelOffset(-55)
          */
@@ -984,7 +984,7 @@ define(function(require) {
         /**
          * Exposes ability to set the format of x-axis values
          * @param  {String} _x               Desired height for the chart
-         * @return {yAxisFormat | module}    Current width or Chart module to chain calls
+         * @return {yAxisFormat | module}    Current xAxisFormat or Chart module to chain calls
          * @public
          */
         exports.xAxisFormat = function (_x) {
@@ -999,7 +999,7 @@ define(function(require) {
         /**
          * Gets or Sets the xTicks of the chart
          * @param  {Number} _x         Desired height for the chart
-         * @return {xTicks | module}    Current width or Chart module to chain calls
+         * @return {xTicks | module}   Current xTicks or Chart module to chain calls
          * @public
          */
         exports.xTicks = function(_x) {
@@ -1014,7 +1014,7 @@ define(function(require) {
         /**
          * Exposes ability to set the format of y-axis values
          * @param  {String} _x               Desired height for the chart
-         * @return {yAxisFormat | module}    Current width or Chart module to chain calls
+         * @return {yAxisFormat | module}    Current yAxisFormat or Chart module to chain calls
          * @public
          */
         exports.yAxisFormat = function(_x) {
@@ -1046,7 +1046,7 @@ define(function(require) {
          * Gets or Sets the offset of the yAxisLabel of the chart.
          * The method accepts both positive and negative values.
          * @param  {Number} _x=-40      Desired offset for the label
-         * @return {yAxisLabelOffset | module}    Current yAxisLabelOffset or Chart module to chain calls
+         * @return {Number | module}    Current yAxisLabelOffset or Chart module to chain calls
          * @public
          * @example scatterPlot.yAxisLabelOffset(-55)
          */
@@ -1061,8 +1061,8 @@ define(function(require) {
 
         /**
          * Gets or Sets the xTicks of the chart
-         * @param  {Number} _x         Desired height for the chart
-         * @return {xTicks | module}    Current width or Chart module to chain calls
+         * @param  {Number} _x          Desired height for the chart
+         * @return {Number | module}    Current yTicks or Chart module to chain calls
          * @public
          */
         exports.yTicks = function(_x) {

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -123,13 +123,13 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
                 expect(actual).toBe(expected);
             });
 
-            it('should provide hasHighlightedValues getter and setter', () => {
+            it('should provide hasCrossHairs getter and setter', () => {
                 let previous = scatterPlot.hasHollowCircles(),
                     expected = true,
                     actual;
 
-                scatterPlot.hasHighlightedValues(expected);
-                actual = scatterPlot.hasHighlightedValues();
+                scatterPlot.hasCrossHairs(expected);
+                actual = scatterPlot.hasCrossHairs();
 
                 expect(previous).not.toBe(expected);
                 expect(actual).toEqual(expected);

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -123,6 +123,18 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
                 expect(actual).toBe(expected);
             });
 
+            it('should provide hasHighlightedValues getter and setter', () => {
+                let previous = scatterPlot.hasHollowCircles(),
+                    expected = true,
+                    actual;
+
+                scatterPlot.hasHighlightedValues(expected);
+                actual = scatterPlot.hasHighlightedValues();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toEqual(expected);
+            });
+
             it('should provide hasHollowCircles getter and setter', () => {
                 let previous = scatterPlot.hasHollowCircles(),
                     expected = true,
@@ -136,12 +148,24 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
             });
 
             it('should provide height getter and setter', () => {
-                let previous = scatterPlot.width(),
+                let previous = scatterPlot.height(),
                     expected = 200,
                     actual;
 
                 scatterPlot.height(expected);
                 actual = scatterPlot.height();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
+
+            it('should provide highlightTextLegendOffset getter and setter', () => {
+                let previous = scatterPlot.highlightTextLegendOffset(),
+                    expected = -55,
+                    actual;
+
+                scatterPlot.highlightTextLegendOffset(expected);
+                actual = scatterPlot.highlightTextLegendOffset();
 
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);


### PR DESCRIPTION
Added ability to highlight data point and its values with line and legends.

## Description
This PR gives user ability to have a highlighting on hovered data point (see screenshots). The user needs to set `hasHighlightedValues` to *true* to see this feature.

## Motivation and Context
Alternative to tooltip value highlight

## How Has This Been Tested?
* Added test for setting the distance between the text legends and axises (offset)
* Added test for setting 

## Screenshots (if appropriate):
![britecharts_scatter_voronoi_highlight](https://user-images.githubusercontent.com/31934144/38189807-79f63948-3616-11e8-85b9-5bed49838a15.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
