### PR TITLE
Fix - data point attached to clipPath to not interrupt overlays

### DIFF
--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -421,7 +421,7 @@ define(function(require) {
         function drawMaskingClip() {
             maskingRectangle = svg.selectAll('.chart-group')
               .append('clipPath')
-              .attr('class', maskingRectangleId)
+              .attr('id', maskingRectangleId)
                 .append('rect')
                 .attr('width', chartWidth)
                 .attr('height', chartHeight)
@@ -455,7 +455,7 @@ define(function(require) {
         */
         function drawDataPoints() {
             let circles = svg.select('.chart-group')
-                .attr('clip-path', `url(${maskingRectangleId})`)
+                .attr('clip-path', `url(#${maskingRectangleId})`)
                 .selectAll('circle')
                 .data(dataPoints)
                 .enter();
@@ -697,7 +697,7 @@ define(function(require) {
             }
 
             let highlightCircle = svg.select('.chart-group')
-                .attr('clip-path', `url(${maskingRectangleId})`)
+                .attr('clip-path', `url(#${maskingRectangleId})`)
                 .selectAll('circle.highlight-circle')
                    .data([data])
                    .enter()

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -141,6 +141,8 @@ define(function(require) {
         circleOpacity = 0.24,
         highlightCircleOpacity = circleOpacity,
         maxCircleArea = 10,
+        maskingRectangle,
+        maskingRectangleId = 'scatter-clip-path',
         maxDistanceFromPoint = 50,
 
         colorSchema = colorHelper.colorSchemas.britecharts,
@@ -187,6 +189,7 @@ define(function(require) {
                 drawAxis();
                 drawGridLines();
                 drawDataPoints();
+                drawMaskingClip()
 
                 addMouseEvents();
             });
@@ -409,6 +412,24 @@ define(function(require) {
         }
 
         /**
+         * Draws a masking clip for data points/circles
+         * to refer to. This will allow dots to have lower priority
+         * in the DOM.
+         * @return {void}
+         * @private
+         */
+        function drawMaskingClip() {
+            maskingRectangle = svg.selectAll('.chart-group')
+              .append('clipPath')
+              .attr('class', maskingRectangleId)
+                .append('rect')
+                .attr('width', chartWidth)
+                .attr('height', chartHeight)
+                .attr('x', 0)
+                .attr('y', 0);
+        }
+
+        /**
          * Draws vertical gridlines of the chart
          * These gridlines are parallel to y-axis
          * @return {void}
@@ -434,6 +455,7 @@ define(function(require) {
         */
         function drawDataPoints() {
             let circles = svg.select('.chart-group')
+                .attr('clip-path', `url(${maskingRectangleId})`)
                 .selectAll('circle')
                 .data(dataPoints)
                 .enter();
@@ -674,20 +696,21 @@ define(function(require) {
                 highlightFilterId = createGlowWithMatrix(highlightFilter);
             }
 
-            let highlightCircle = svg.select('.metadata-group')
+            let highlightCircle = svg.select('.chart-group')
+                .attr('clip-path', `url(${maskingRectangleId})`)
                 .selectAll('circle.highlight-circle')
-                .data([data])
-                .enter()
-                  .append('circle')
-                    .attr('class', 'highlight-circle')
-                    .attr('stroke', ({name}) => nameColorMap[name])
-                    .attr('fill', ({name}) => nameColorMap[name])
-                    .attr('fill-opacity', circleOpacity)
-                    .attr('cx', ({x}) => xScale(x))
-                    .attr('cy', ({y}) => yScale(y))
-                    .attr('r', ({y}) => areaScale(y))
-                    .style('stroke-width', highlightStrokeWidth)
-                    .style('stroke-opacity', highlightCircleOpacity);
+                   .data([data])
+                   .enter()
+                     .append('circle')
+                       .attr('class', 'highlight-circle')
+                       .attr('stroke', ({name}) => nameColorMap[name])
+                       .attr('fill', ({name}) => nameColorMap[name])
+                       .attr('fill-opacity', circleOpacity)
+                       .attr('cx', ({x}) => xScale(x))
+                       .attr('cy', ({y}) => yScale(y))
+                       .attr('r', ({y}) => areaScale(y))
+                       .style('stroke-width', highlightStrokeWidth)
+                       .style('stroke-opacity', highlightCircleOpacity);
 
             // apply glow container overlay
             highlightCircle

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -49,7 +49,7 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
 
         it('should render clip-path container', () => {
             let expected = 1;
-            let actual = containerFixture.select('.scatter-clip-path').nodes().length;
+            let actual = containerFixture.select('#scatter-clip-path').nodes().length;
 
             expect(actual).toEqual(expected);
         });

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -47,6 +47,14 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
             expect(actual).toEqual(expected);
         });
 
+        it('should render clip-path container', () => {
+            let expected = 1;
+            let actual = containerFixture.select('.scatter-clip-path').nodes().length;
+
+            expect(actual).toEqual(expected);
+        });
+
+
         it('should render container, axis and chart groups', () => {
             expect(containerFixture.select('g.container-group').empty()).toBeFalsy();
             expect(containerFixture.select('g.chart-group').empty()).toBeFalsy();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Without clip path, the tooltip highlight and points would appear over the tooltip. Placing clip path solves the issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The points were on the top of the tooltip (the opposite of expected behavior)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a new test that checks if clip-path masking component is rendered

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
