### PR TITLE
Fix - Scatter Plot highlighter should not interrupt the mousemove behavior 

### DIFF
--- a/demos/css/britecharts.css
+++ b/demos/css/britecharts.css
@@ -125,6 +125,9 @@
 .scatter-plot .x.axis path {
   display: none; }
 
+.scatter-plot .highlight-circle {
+  cursor: pointer; }
+
 .scatter-plot .data-point-highlighter {
   stroke-width: 1.2; }
 

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -200,8 +200,8 @@ define(function(require) {
 
         /**
          * Add mouse event handlers over svg
-         * @private
          * @return {void}
+         * @private
          */
         function addMouseEvents() {
             svg
@@ -218,8 +218,8 @@ define(function(require) {
 
         /**
          * Creates the x-axis and y-axis with proper orientations
-         * @private
          * @return {void}
+         * @private
         */
         function buildAxis() {
             xAxis = d3Axis.axisBottom(xScale)
@@ -236,8 +236,8 @@ define(function(require) {
         /**
          * Builds containers for the chart, including the chart axis,
          * chart, and metadata groups.
-         * @private
          * @return {void}
+         * @private
         */
         function buildContainerGroups() {
             let container = svg

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -660,6 +660,10 @@ define(function(require) {
             let { mousePos, closestPoint } = getPointProps(e);
             let pointData = getPointData(closestPoint);
 
+            if (hasCrossHairs) {
+                drawDataPointsValueHighlights(pointData);
+            }
+
             highlightDataPoint(pointData);
 
             dispatcher.call('customMouseMove', e, pointData, d3Selection.mouse(e), [chartWidth, chartHeight]);
@@ -726,10 +730,6 @@ define(function(require) {
             // apply glow container overlay
             highlightCircle
                 .attr('filter', `url(#${highlightFilterId})`);
-
-            if (hasCrossHairs) {
-                drawDataPointsValueHighlights(data);
-            }
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -140,6 +140,7 @@ define(function(require) {
         },
 
         circleOpacity = 0.24,
+        highlightCircle = null,
         highlightCircleOpacity = circleOpacity,
         maxCircleArea = 10,
         maskingRectangle,
@@ -189,6 +190,7 @@ define(function(require) {
                 buildVoronoi();
                 drawAxis();
                 drawGridLines();
+                initHighlightPoint();
                 drawDataPoints();
                 drawMaskingClip()
 
@@ -711,25 +713,31 @@ define(function(require) {
                 highlightFilterId = createGlowWithMatrix(highlightFilter);
             }
 
-            let highlightCircle = svg.select('.chart-group')
-                .attr('clip-path', `url(#${maskingRectangleId})`)
-                .selectAll('circle.highlight-circle')
-                   .data([data])
-                   .enter()
-                     .append('circle')
-                       .attr('class', 'highlight-circle')
-                       .attr('stroke', ({name}) => nameColorMap[name])
-                       .attr('fill', ({name}) => nameColorMap[name])
-                       .attr('fill-opacity', circleOpacity)
-                       .attr('cx', ({x}) => xScale(x))
-                       .attr('cy', ({y}) => yScale(y))
-                       .attr('r', ({y}) => areaScale(y))
-                       .style('stroke-width', highlightStrokeWidth)
-                       .style('stroke-opacity', highlightCircleOpacity);
+            highlightCircle
+                .attr('opacity', 1)
+                .attr('stroke', () => nameColorMap[data.name])
+                .attr('fill', () => nameColorMap[data.name])
+                .attr('fill-opacity', circleOpacity)
+                .attr('cx', () => xScale(data.x))
+                .attr('cy', () => yScale(data.y))
+                .attr('r', () => areaScale(data.y))
+                .style('stroke-width', highlightStrokeWidth)
+                .style('stroke-opacity', highlightCircleOpacity);
 
             // apply glow container overlay
             highlightCircle
                 .attr('filter', `url(#${highlightFilterId})`);
+        }
+
+        function initHighlightPoint() {
+            highlightCircle = svg.select('.chart-group')
+                .attr('clip-path', `url(#${maskingRectangleId})`)
+                .selectAll('circle.highlight-circle')
+                .data([1])
+                .enter()
+                  .append('circle')
+                    .attr('class', 'highlight-circle')
+                    .attr('opacity', 0);
         }
 
         /**
@@ -738,7 +746,7 @@ define(function(require) {
          * @private
          */
         function removePointHighlight() {
-            svg.selectAll('circle.highlight-circle').remove();
+            svg.selectAll('circle.highlight-circle').attr('opacity', 0);
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -729,6 +729,13 @@ define(function(require) {
                 .attr('filter', `url(#${highlightFilterId})`);
         }
 
+        /**
+         * Places the highlighter point to the DOM
+         * to be used once one of the data points is
+         * highlighted
+         * @return {void}
+         * @private
+        */
         function initHighlightPoint() {
             highlightCircle = svg.select('.metadata-group')
                 .selectAll('circle.highlight-circle')

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -730,14 +730,12 @@ define(function(require) {
         }
 
         function initHighlightPoint() {
-            highlightCircle = svg.select('.chart-group')
-                .attr('clip-path', `url(#${maskingRectangleId})`)
+            highlightCircle = svg.select('.metadata-group')
                 .selectAll('circle.highlight-circle')
                 .data([1])
                 .enter()
                   .append('circle')
-                    .attr('class', 'highlight-circle')
-                    .attr('opacity', 0);
+                    .attr('class', 'highlight-circle');
         }
 
         /**

--- a/src/styles/charts/scatter-plot.scss
+++ b/src/styles/charts/scatter-plot.scss
@@ -20,6 +20,10 @@ $outline-stroke-width: 1.2;
         display: none;
     }
 
+    .highlight-circle {
+        cursor: pointer;
+    }
+
     .data-point-highlighter {
         stroke-width: $outline-stroke-width;
     }


### PR DESCRIPTION
## Description
Added fix for the highlighter to not interrupt the previous behavior where the tooltip and highlight were disappearing when you hover right over the circle area.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug fix for highlighting points in Scatter Plote

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
*Before:*
![britecharts_scatter_voronoi_highlight_fix_before](https://user-images.githubusercontent.com/31934144/38264842-1fbf0b3a-3729-11e8-9914-d2a2cc50ef81.gif)

*After:*
![britecharts_scatter_voronoi_highlight_fix_after](https://user-images.githubusercontent.com/31934144/38264865-2b1facf0-3729-11e8-8dc7-cd8bb3926dd1.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
