### PR TITLE
Fix - scatter plot crosshair lines should not display over tooltip

### DIFF
--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -611,7 +611,7 @@ define(function(require) {
                 .enter()
                   .append('line')
                     .attr('class', 'extended-x-line')
-                    .attr('x1', (xAxisPadding.left))
+                    .attr('x1', xAxisPadding.left)
                     .attr('x2', chartWidth)
                     .attr('y1', chartHeight)
                     .attr('y2', chartHeight);
@@ -630,7 +630,7 @@ define(function(require) {
                 .enter()
                   .append('line')
                     .attr('class', 'horizontal-grid-line')
-                    .attr('x1', (xAxisPadding.left))
+                    .attr('x1', xAxisPadding.left)
                     .attr('x2', chartWidth)
                     .attr('y1', (d) => yScale(d))
                     .attr('y2', (d) => yScale(d))
@@ -658,7 +658,7 @@ define(function(require) {
          * @return {void}
          * @private
          */
-        function handleMouseMove(e, d) {
+        function handleMouseMove(e) {
             let { mousePos, closestPoint } = getPointProps(e);
             let pointData = getPointData(closestPoint);
 

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -475,6 +475,7 @@ define(function(require) {
             if (isAnimated) {
                 circles
                     .append('circle')
+                    .attr('class', 'data-point data-point-highlighter')
                     .on('click', function (d) {
                         handleClick(this, d, chartWidth, chartHeight);
                     })
@@ -482,8 +483,6 @@ define(function(require) {
                     .delay(delay)
                     .duration(duration)
                     .ease(ease)
-                    .attr('class', 'point')
-                    .attr('class', 'data-point-highlighter')
                     .style('stroke', (d) => nameColorMap[d.name])
                     .attr('fill', (d) => (
                         hasHollowCircles ? hollowColor : nameColorMap[d.name]

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -524,7 +524,7 @@ define(function(require) {
                 removeDataPointsValueHighlights();
             }
 
-            highlightContainer = svg.select('.metadata-group')
+            highlightContainer = svg.select('.chart-group')
                 .append('g')
                 .classed('data-point-value-highlight', true);
 
@@ -536,7 +536,7 @@ define(function(require) {
                   .attr('stroke', ({name}) => nameColorMap[name])
                   .attr('class', 'highlight-y-line')
                   .attr('x1', (d) => (xScale(d.x) - areaScale(d.y)))
-                  .attr('x2', (d) => 0)
+                  .attr('x2', 0)
                   .attr('y1', (d) => yScale(d.y))
                   .attr('y2', (d) => yScale(d.y));
 
@@ -551,7 +551,7 @@ define(function(require) {
                   .attr('x1', (d) => xScale(d.x))
                   .attr('x2', (d) => xScale(d.x))
                   .attr('y1', (d) => (yScale(d.y) + areaScale(d.y)))
-                  .attr('y2', (d) => chartHeight);
+                  .attr('y2', chartHeight);
 
             // Draw data label for y value
             highlightContainer.selectAll('text.highlight-y-legend')

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -362,10 +362,10 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
             });
 
             it('should have proper default parameteres', () => {
-                let circles = containerFixture.selectAll('.chart-group circle').nodes();
+                let circles = containerFixture.selectAll('.chart-group circle.data-point').nodes();
 
                 circles.forEach((circle) => {
-                    expect(circle).toHaveAttr('class', 'data-point-highlighter');
+                    expect(circle).toHaveAttr('class', 'data-point data-point-highlighter');
                     expect(circle).toHaveAttr('fill-opacity', '0.24');
                     expect(circle).toHaveAttr('fill');
                     expect(circle).toHaveAttr('cx');
@@ -448,6 +448,38 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
                 let actual = containerFixture.select('.highlight-circle').nodes().length;
 
                 expect(actual).toEqual(expected);
+            });
+
+            it('initially has only class and cursor attributes', () => {
+                let expectedCursor = 'pointer';
+                let expectedClass = 'highlight-circle';
+                let scatterPoint = containerFixture.selectAll('.highlight-circle').node();
+
+                expect(scatterPoint).toHaveAttr('cursor', expectedCursor);
+                expect(scatterPoint).toHaveAttr('class', expectedClass);
+            });
+
+            it('should change attribute when a data point is hovered', () => {
+                let expectedCursor = 'pointer';
+                let expectedOpacity = '1';
+                let expectedStroke ='#6aedc7';
+                let expectedFillOpacity ='0.24';
+                let expectedCx='39';
+                let expectedCy='398';
+                let expectedFilter='url(#highlight-filter)';
+                let container = containerFixture.select('svg');
+
+                container.dispatch('mousemove');
+                let scatterPoint = containerFixture.selectAll('.highlight-circle').node();
+
+                expect(scatterPoint).toHaveAttr('cursor', expectedCursor);
+                expect(scatterPoint).toHaveAttr('opacity', expectedOpacity);
+                expect(scatterPoint).toHaveAttr('stroke', expectedStroke);
+                expect(scatterPoint).toHaveAttr('fill', expectedStroke);
+                expect(scatterPoint).toHaveAttr('fill-opacity', expectedFillOpacity);
+                expect(scatterPoint).toHaveAttr('cx', expectedCx);
+                expect(scatterPoint).toHaveAttr('cy', expectedCy);
+                expect(scatterPoint).toHaveAttr('filter', expectedFilter);
             });
         });
 

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -441,6 +441,16 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
             });
         });
 
+        describe('Point highlighter', () => {
+
+            it('is successfully initialized on render', () => {
+                let expected = 1;
+                let actual = containerFixture.select('.highlight-circle').nodes().length;
+
+                expect(actual).toEqual(expected);
+            });
+        });
+
         describe('when margins are set partially', function() {
 
             it('should override the default values', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a fix for the Scatter Plot. The crosshair lines showed up over the tooltip, so I placed them under path clip - in the same level as highlight point. I will add more tests in the future.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The crosshair lines showed up on the top of tooltip, this should not happen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a few more tests to make sure that highlight point shows up on hover

## Screenshots (if appropriate):
*Before:*
![screen shot 2018-04-03 at 9 28 35 pm](https://user-images.githubusercontent.com/9118852/38289792-d666773e-378c-11e8-9fd1-f8ee0647b67f.png)

*After:*
![screen shot 2018-04-03 at 9 31 13 pm](https://user-images.githubusercontent.com/9118852/38289794-d8cc2afa-378c-11e8-9698-86fce721aaf3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
