### PR TITLE
Fix - crosshair lines have a lower priority than tooltip and overlays

### DIFF
--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -524,6 +524,11 @@ define(function(require) {
 
             setCrossHairLinesStatus(1);
 
+            // initialize cross hair labels container
+            highlightCrossHairLabelsContainer = svg.select('.metadata-group')
+            .append('g')
+            .attr('class', 'crosshair-labels-container');
+
             // Draw line perpendicular to y-axis
             highlightCrossHairContainer.selectAll('line.highlight-y-line')
               .attr('stroke', nameColorMap[data.name])
@@ -756,11 +761,6 @@ define(function(require) {
                   .enter()
                     .append('line')
                     .attr('class', 'highlight-x-line');
-
-                // initialize cross hair labels container
-                highlightCrossHairLabelsContainer = svg.select('.metadata-group')
-                  .append('g')
-                  .attr('class', 'crosshair-labels-container');
             }
         }
 
@@ -786,8 +786,8 @@ define(function(require) {
          * Sets the visibility of cross hair lines
          * if 1, it sets lines to visible,
          * if 0, it hides lines
-         * @return
-         * @param {boolean}
+         * @return {void}
+         * @param {Number}
          * @private
          */
         function setCrossHairLinesStatus(status = 0) {

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -129,8 +129,8 @@ define(function(require) {
         highlightFilter,
         highlightFilterId,
         highlightStrokeWidth = 10,
-        highlightContainer,
         highlightCrossHairContainer,
+        highlightCrossHairLabelsContainer,
         highlightTextLegendOffset = -45,
 
         xAxisPadding = {
@@ -520,22 +520,22 @@ define(function(require) {
          * @private
         */
         function drawDataPointsValueHighlights(data) {
-            if (highlightContainer) {
+            if (highlightCrossHairContainer) {
                 removeDataPointsValueHighlights();
             }
 
-            highlightContainer = svg.select('.chart-group')
+            highlightCrossHairContainer= svg.select('.chart-group')
                 .append('g')
                 .classed('data-point-value-highlight', true);
 
             // the crosshair labels needs to be placed outside of
             // chart group, hence, metadata-group is used
-            highlightCrossHairContainer = svg.select('.metadata-group')
+            highlightCrossHairLabelsContainer = svg.select('.metadata-group')
                 .append('g')
                   .attr('class', 'crosshair-labels');
 
-            // Draw line perpendicular to y-axis
-            highlightContainer.selectAll('line.highlight-y-line')
+                // Draw line perpendicular to y-axis
+            highlightCrossHairContainer.selectAll('line.highlight-y-line')
                 .data([data])
                 .enter()
                 .append('line')
@@ -548,7 +548,7 @@ define(function(require) {
 
 
             // Draw line perpendicular to x-axis
-            highlightContainer.selectAll('line.highlight-x-line')
+            highlightCrossHairContainer.selectAll('line.highlight-x-line')
                 .data([data])
                 .enter()
                 .append('line')
@@ -560,7 +560,7 @@ define(function(require) {
                   .attr('y2', chartHeight);
 
             // Draw data label for y value
-            highlightCrossHairContainer.selectAll('text.highlight-y-legend')
+            highlightCrossHairLabelsContainer.selectAll('text.highlight-y-legend')
                 .data([data])
                 .enter()
                 .append('text')
@@ -572,7 +572,7 @@ define(function(require) {
                   .text((d) => `${d3Format.format(yAxisFormat)(d.y)}`);
 
             // Draw data label for x value
-            highlightCrossHairContainer.selectAll('text.highlight-x-legend')
+            highlightCrossHairLabelsContainer.selectAll('text.highlight-x-legend')
                 .data([data])
                 .enter()
                 .append('text')
@@ -750,6 +750,7 @@ define(function(require) {
                   .append('circle')
                     .attr('class', 'highlight-circle')
                     .attr('cursor', 'pointer');
+
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -520,60 +520,58 @@ define(function(require) {
          * @private
         */
         function drawDataPointsValueHighlights(data) {
-            if (highlightCrossHairContainer) {
-                removeDataPointsValueHighlights();
+            removeDataPointsValueHighlights();
 
-                setCrossHairLinesStatus(1);
+            setCrossHairLinesStatus(1);
 
-                // Draw line perpendicular to y-axis
-                highlightCrossHairContainer.selectAll('line.highlight-y-line')
-                  .attr('stroke', nameColorMap[data.name])
-                  .attr('class', 'highlight-y-line')
-                  .attr('x1', (xScale(data.x) - areaScale(data.y)))
-                  .attr('x2', 0)
-                  .attr('y1', yScale(data.y))
-                  .attr('y2', yScale(data.y));
+            // Draw line perpendicular to y-axis
+            highlightCrossHairContainer.selectAll('line.highlight-y-line')
+                .attr('stroke', nameColorMap[data.name])
+                .attr('class', 'highlight-y-line')
+                .attr('x1', (xScale(data.x) - areaScale(data.y)))
+                .attr('x2', 0)
+                .attr('y1', yScale(data.y))
+                .attr('y2', yScale(data.y));
 
 
-                // Draw line perpendicular to x-axis
-                highlightCrossHairContainer.selectAll('line.highlight-x-line')
-                  .attr('stroke', nameColorMap[data.name])
-                  .attr('class', 'highlight-x-line')
-                  .attr('x1', xScale(data.x))
-                  .attr('x2', xScale(data.x))
-                  .attr('y1', (yScale(data.y) + areaScale(data.y)))
-                  .attr('y2', chartHeight);
+            // Draw line perpendicular to x-axis
+            highlightCrossHairContainer.selectAll('line.highlight-x-line')
+                .attr('stroke', nameColorMap[data.name])
+                .attr('class', 'highlight-x-line')
+                .attr('x1', xScale(data.x))
+                .attr('x2', xScale(data.x))
+                .attr('y1', (yScale(data.y) + areaScale(data.y)))
+                .attr('y2', chartHeight);
 
-                // the crosshair labels needs to be placed outside of
-                // chart group, hence, metadata-group is used
-                highlightCrossHairLabelsContainer = svg.select('.metadata-group')
-                    .append('g')
-                    .attr('class', 'crosshair-labels');
+            // the crosshair labels needs to be placed outside of
+            // chart group, hence, metadata-group is used
+            highlightCrossHairLabelsContainer = svg.select('.metadata-group')
+                .append('g')
+                .attr('class', 'crosshair-labels');
 
-                // Draw data label for y value
-                highlightCrossHairLabelsContainer.selectAll('text.highlight-y-legend')
-                    .data([data])
-                    .enter()
-                    .append('text')
-                    .attr('text-anchor', 'middle')
-                    .attr('fill', ({name}) => nameColorMap[name])
-                    .attr('class', 'highlight-y-legend')
-                    .attr('y', (d) => (yScale(d.y) + (areaScale(d.y) / 2)))
-                    .attr('x', highlightTextLegendOffset)
-                    .text((d) => `${d3Format.format(yAxisFormat)(d.y)}`);
+            // Draw data label for y value
+            highlightCrossHairLabelsContainer.selectAll('text.highlight-y-legend')
+                .data([data])
+                .enter()
+                .append('text')
+                .attr('text-anchor', 'middle')
+                .attr('fill', ({name}) => nameColorMap[name])
+                .attr('class', 'highlight-y-legend')
+                .attr('y', (d) => (yScale(d.y) + (areaScale(d.y) / 2)))
+                .attr('x', highlightTextLegendOffset)
+                .text((d) => `${d3Format.format(yAxisFormat)(d.y)}`);
 
-                // Draw data label for x value
-                highlightCrossHairLabelsContainer.selectAll('text.highlight-x-legend')
-                    .data([data])
-                    .enter()
-                    .append('text')
-                    .attr('text-anchor', 'middle')
-                    .attr('fill', ({name}) => nameColorMap[name])
-                    .attr('class', 'highlight-x-legend')
-                    .attr('transform', `translate(0, ${chartHeight - highlightTextLegendOffset})`)
-                    .attr('x', (d) => (xScale(d.x) - (areaScale(d.y) / 2)))
-                    .text((d) => `${d3Format.format(xAxisFormat)(d.x)}`);
-            }
+            // Draw data label for x value
+            highlightCrossHairLabelsContainer.selectAll('text.highlight-x-legend')
+                .data([data])
+                .enter()
+                .append('text')
+                .attr('text-anchor', 'middle')
+                .attr('fill', ({name}) => nameColorMap[name])
+                .attr('class', 'highlight-x-legend')
+                .attr('transform', `translate(0, ${chartHeight - highlightTextLegendOffset})`)
+                .attr('x', (d) => (xScale(d.x) - (areaScale(d.y) / 2)))
+                .text((d) => `${d3Format.format(xAxisFormat)(d.x)}`);
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -526,34 +526,28 @@ define(function(require) {
 
             // Draw line perpendicular to y-axis
             highlightCrossHairContainer.selectAll('line.highlight-y-line')
-                .attr('stroke', nameColorMap[data.name])
-                .attr('class', 'highlight-y-line')
-                .attr('x1', (xScale(data.x) - areaScale(data.y)))
-                .attr('x2', 0)
-                .attr('y1', yScale(data.y))
-                .attr('y2', yScale(data.y));
+              .attr('stroke', nameColorMap[data.name])
+              .attr('class', 'highlight-y-line')
+              .attr('x1', (xScale(data.x) - areaScale(data.y)))
+              .attr('x2', 0)
+              .attr('y1', yScale(data.y))
+              .attr('y2', yScale(data.y));
 
 
             // Draw line perpendicular to x-axis
             highlightCrossHairContainer.selectAll('line.highlight-x-line')
-                .attr('stroke', nameColorMap[data.name])
-                .attr('class', 'highlight-x-line')
-                .attr('x1', xScale(data.x))
-                .attr('x2', xScale(data.x))
-                .attr('y1', (yScale(data.y) + areaScale(data.y)))
-                .attr('y2', chartHeight);
-
-            // the crosshair labels needs to be placed outside of
-            // chart group, hence, metadata-group is used
-            highlightCrossHairLabelsContainer = svg.select('.metadata-group')
-                .append('g')
-                .attr('class', 'crosshair-labels');
+              .attr('stroke', nameColorMap[data.name])
+              .attr('class', 'highlight-x-line')
+              .attr('x1', xScale(data.x))
+              .attr('x2', xScale(data.x))
+              .attr('y1', (yScale(data.y) + areaScale(data.y)))
+              .attr('y2', chartHeight);
 
             // Draw data label for y value
             highlightCrossHairLabelsContainer.selectAll('text.highlight-y-legend')
-                .data([data])
-                .enter()
-                .append('text')
+            .data([data])
+            .enter()
+              .append('text')
                 .attr('text-anchor', 'middle')
                 .attr('fill', ({name}) => nameColorMap[name])
                 .attr('class', 'highlight-y-legend')
@@ -563,15 +557,15 @@ define(function(require) {
 
             // Draw data label for x value
             highlightCrossHairLabelsContainer.selectAll('text.highlight-x-legend')
-                .data([data])
-                .enter()
+            .data([data])
+              .enter()
                 .append('text')
-                .attr('text-anchor', 'middle')
-                .attr('fill', ({name}) => nameColorMap[name])
-                .attr('class', 'highlight-x-legend')
-                .attr('transform', `translate(0, ${chartHeight - highlightTextLegendOffset})`)
-                .attr('x', (d) => (xScale(d.x) - (areaScale(d.y) / 2)))
-                .text((d) => `${d3Format.format(xAxisFormat)(d.x)}`);
+                  .attr('text-anchor', 'middle')
+                  .attr('fill', ({name}) => nameColorMap[name])
+                  .attr('class', 'highlight-x-legend')
+                  .attr('transform', `translate(0, ${chartHeight - highlightTextLegendOffset})`)
+                  .attr('x', (d) => (xScale(d.x) - (areaScale(d.y) / 2)))
+                  .text((d) => `${d3Format.format(xAxisFormat)(d.x)}`);
         }
 
         /**
@@ -746,21 +740,27 @@ define(function(require) {
                     .attr('cursor', 'pointer');
 
             if (hasCrossHairs) {
+                // initialize cross hair lines container
                 highlightCrossHairContainer = svg.select('.chart-group')
-                .append('g')
-                .classed('data-point-value-highlight', true);
+                  .append('g')
+                  .attr('class', 'crosshair-lines-container');
 
-              highlightCrossHairContainer.selectAll('line.highlight-y-line')
-                .data([1])
-                .enter()
-                  .append('line')
+                highlightCrossHairContainer.selectAll('line.highlight-y-line')
+                  .data([1])
+                  .enter()
+                    .append('line')
                     .attr('class', 'highlight-y-line');
 
-              highlightCrossHairContainer.selectAll('line.highlight-x-line')
-                .data([1])
-                .enter()
+                highlightCrossHairContainer.selectAll('line.highlight-x-line')
+                  .data([1])
+                  .enter()
                     .append('line')
-                      .attr('class', 'highlight-x-line');
+                    .attr('class', 'highlight-x-line');
+
+                // initialize cross hair labels container
+                highlightCrossHairLabelsContainer = svg.select('.metadata-group')
+                  .append('g')
+                  .attr('class', 'crosshair-labels-container');
             }
         }
 
@@ -779,7 +779,7 @@ define(function(require) {
          * @private
          */
         function removeDataPointsValueHighlights() {
-            svg.selectAll('.crosshair-labels').remove();
+            svg.selectAll('.crosshair-labels-container').remove();
         }
 
         /**

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -483,6 +483,66 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
             });
         });
 
+        describe('when hasCrossHairs is set to true', () => {
+
+            beforeEach(() => {
+                scatterPlot.hasCrossHairs(true);
+                containerFixture.datum(dataset).call(scatterPlot);
+            });
+
+            describe('cross hair lines', () => {
+
+                it('successfully initialized with container on render', () => {
+                    let expected = 1;
+                    let textContainer = containerFixture.select('.crosshair-lines-container').nodes().length;
+                    let testXLine = containerFixture.select('line.highlight-x-line').nodes().length;
+                    let testYLine = containerFixture.select('line.highlight-y-line').nodes().length;
+
+                    expect(textContainer).toEqual(expected);
+                    expect(testXLine).toEqual(expected);
+                    expect(testYLine).toEqual(expected);
+                });
+
+                it('crosshair line with respect to x changes attributes', () => {
+                    let container = containerFixture.select('svg');
+                    let expectedStroke = '#6aedc7';
+
+                    container.dispatch('mousemove');
+                    let scatterPoint = containerFixture.select('line.highlight-x-line').node();
+
+                    expect(scatterPoint).toHaveAttr('stroke', expectedStroke);
+                    expect(scatterPoint).toHaveAttr('x1');
+                    expect(scatterPoint).toHaveAttr('x2');
+                    expect(scatterPoint).toHaveAttr('y1');
+                    expect(scatterPoint).toHaveAttr('y2');
+                });
+
+                it('crosshair line with respect to y changes attributes', () => {
+                    let container = containerFixture.select('svg');
+                    let expectedStroke = '#6aedc7';
+
+                    container.dispatch('mousemove');
+                    let scatterPoint = containerFixture.select('line.highlight-y-line').node();
+
+                    expect(scatterPoint).toHaveAttr('stroke', expectedStroke);
+                    expect(scatterPoint).toHaveAttr('x1');
+                    expect(scatterPoint).toHaveAttr('x2');
+                    expect(scatterPoint).toHaveAttr('y1');
+                    expect(scatterPoint).toHaveAttr('y2');
+                });
+            });
+
+            describe('cross hair labels', () => {
+
+                it('successfully initialized with container on render', () => {
+                    let expected = 1;
+                    let textContainer = containerFixture.select('.crosshair-labels-container').nodes().length;
+
+                    expect(textContainer).toEqual(expected);
+                });
+            });
+        });
+
         describe('when margins are set partially', function() {
 
             it('should override the default values', () => {

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -494,11 +494,11 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
 
                 it('successfully initialized with container on render', () => {
                     let expected = 1;
-                    let textContainer = containerFixture.select('.crosshair-lines-container').nodes().length;
+                    let testContainer = containerFixture.select('.crosshair-lines-container').nodes().length;
                     let testXLine = containerFixture.select('line.highlight-x-line').nodes().length;
                     let testYLine = containerFixture.select('line.highlight-y-line').nodes().length;
 
-                    expect(textContainer).toEqual(expected);
+                    expect(testContainer).toEqual(expected);
                     expect(testXLine).toEqual(expected);
                     expect(testYLine).toEqual(expected);
                 });
@@ -529,16 +529,6 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
                     expect(scatterPoint).toHaveAttr('x2');
                     expect(scatterPoint).toHaveAttr('y1');
                     expect(scatterPoint).toHaveAttr('y2');
-                });
-            });
-
-            describe('cross hair labels', () => {
-
-                it('successfully initialized with container on render', () => {
-                    let expected = 1;
-                    let textContainer = containerFixture.select('.crosshair-labels-container').nodes().length;
-
-                    expect(textContainer).toEqual(expected);
                 });
             });
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Instead of appending and removing the cross-hair lines, now they are initialized beforehand to not allow them interrupt the `mousemove` movement, and instead of removing them we toggle the `opacity`. The solution is very similar to https://github.com/eventbrite/britecharts/pull/581


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When hovering over lines, the tooltip flickered

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added multiple tests to check if highlighter components rendered in the DOM properly

## Screenshots (if appropriate):
*Before*:
![britecharts_scatter_crosshair_before](https://user-images.githubusercontent.com/9118852/38301523-a328d146-37b4-11e8-94f5-f736d387fdfc.gif)

*After*:
![britecharts_scatter_crosshair_after](https://user-images.githubusercontent.com/9118852/38303387-c9e97d34-37ba-11e8-9a29-89a48081e9b9.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
