### PR TITLE
Fix - scatter plot vertical gridlines use xTicks

### DIFF
--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -451,7 +451,7 @@ define(function(require) {
         function drawVerticalGridLines() {
             maskGridLines = svg.select('.grid-lines-group')
                 .selectAll('line.vertical-grid-line')
-                .data(yScale.ticks(xTicks))
+                .data(xScale.ticks(xTicks))
                 .enter()
                  .append('line')
                   .attr('class', 'vertical-grid-line')
@@ -464,6 +464,7 @@ define(function(require) {
         /**
          * Draws the points for each data element
          * on the chart group
+         * @return {void}
          * @private
         */
         function drawDataPoints() {
@@ -628,7 +629,7 @@ define(function(require) {
                     .attr('x1', xAxisPadding.left)
                     .attr('x2', chartWidth)
                     .attr('y1', (d) => yScale(d))
-                    .attr('y2', (d) => yScale(d))
+                    .attr('y2', (d) => yScale(d));
         }
 
         /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the bug of not drawing full vertical grid lines

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/eventbrite/britecharts/issues/587

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There are tests for grid lines, should probably be improved

## Screenshots (if appropriate):
Before:
<img width="886" alt="screen shot 2018-04-05 at 1 59 56 pm" src="https://user-images.githubusercontent.com/31934144/38391966-bb0448e6-38da-11e8-8183-230ad5683dae.png">
After:
<img width="882" alt="screen shot 2018-04-05 at 2 00 07 pm" src="https://user-images.githubusercontent.com/31934144/38391971-be22bb0c-38da-11e8-844f-2ba179488f27.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
