### PR TITLE
Fix programatic brush selection clear

### DIFF
--- a/demos/brush.html
+++ b/demos/brush.html
@@ -5,7 +5,10 @@
                 <article>
                     <h2 class="tutorial__heading">Simple Brush Chart</h2>
                     <div class="js-brush-chart-container card--chart"></div>
-                    <p class="js-date-range date-range is-hidden">Selected from <span class="js-start-date"></span> to <span class="js-end-date"></span></p>
+                    <p class="js-date-range date-range is-hidden">
+                        Selected from <span class="js-start-date"></span> to <span class="js-end-date"></span><br>
+                        <a id="clear-selection" href="#">Clear Selection</a>
+                    </p>
                     <p>Brush chart to use with other charts as a time range selector.</p>
                 </article>
             </div>

--- a/demos/src/demo-brush.js
+++ b/demos/src/demo-brush.js
@@ -46,18 +46,25 @@ function createBrushChart() {
 
         brushChart.dateRange(['7/15/2015', '7/25/2015'])
     }
+
+    return brushChart;
 }
 
 // Show charts if container available
 if (d3Selection.select('.js-brush-chart-container').node()){
-    createBrushChart();
+    let brushChart = createBrushChart();
 
-    let redrawCharts = function(){
+    const redrawCharts = function () {
         d3Selection.select('.brush-chart').remove();
 
-        createBrushChart();
+        brushChart = createBrushChart();
     };
 
     // Redraw charts on window resize
     PubSub.subscribe('resize', redrawCharts);
+
+    d3Selection.select('#clear-selection').on('click', function (event) {
+        brushChart.dateRange([null, null]);
+        d3Selection.event.preventDefault();
+    });
 }

--- a/src/charts/brush.js
+++ b/src/charts/brush.js
@@ -403,11 +403,16 @@ define(function(require) {
          * @param {String | Date} dateB End Date
          */
         function setBrushByDates(dateA, dateB) {
-            let x0 = xScale(new Date(dateA)),
-                x1 = xScale(new Date(dateB));
+            let selection = null;
 
-            brush
-                .move(chartBrush, [x0, x1]);
+            if (dateA !== null) {
+                selection = [
+                    xScale(new Date(dateA)),
+                    xScale(new Date(dateB))
+                ];
+            }
+
+            brush.move(chartBrush, selection);
         }
 
         // API

--- a/src/charts/brush.js
+++ b/src/charts/brush.js
@@ -355,10 +355,13 @@ define(function(require) {
          * @return {void}
          */
         function handleBrushStart() {
-            let s = d3Selection.event.selection,
-                dateExtent = s.map(xScale.invert);
+            const selection = d3Selection.event.selection;
 
-            dispatcher.call('customBrushStart', this, dateExtent);
+            if (!selection) {
+                return;
+            }
+
+            dispatcher.call('customBrushStart', this, selection.map(xScale.invert));
         }
 
         /**
@@ -373,10 +376,10 @@ define(function(require) {
             }
 
             let dateExtentRounded = [null, null];
+            const selection = d3Selection.event.selection;
 
-            if (d3Selection.event.selection) {
-                let s = d3Selection.event.selection;
-                let dateExtent = s.map(xScale.invert);
+            if (selection) {
+                let dateExtent = selection.map(xScale.invert);
 
                 dateExtentRounded = dateExtent.map(d3Time.timeDay.round);
 


### PR DESCRIPTION
## Description

* Clears brush selection when setting date range to `[null, null]`
* Only dispatches `customBrushStart` event if selection is defined
* Adds "Clear Selection" functionality to Brush Chart demo

## Motivation and Context

Previously, programmatically clearing the date range:

```javascript
brushChart.dateRange([null, null]);
```

would instantiate Date objects with `null`:

https://github.com/eventbrite/britecharts/blob/fa2bd156610e5efa16cc9a7b654c1baa4169238c/src/charts/brush.js#L403-L404

which could result in a JavaScript error:

```
brush.js?d389:332 Uncaught TypeError: Cannot read property 'map' of null
    at SVGGElement.handleBrushStart (brush.js?d389:332)
```

https://github.com/eventbrite/britecharts/blob/fa2bd156610e5efa16cc9a7b654c1baa4169238c/src/charts/brush.js#L359

if the dates were out of bounds.

## Screenshots (if appropriate):

![apr-07-2018 09-11-42](https://user-images.githubusercontent.com/847532/38455271-b980b7d8-3a43-11e8-834a-dc120a50ecba.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
