### PR TITLE
Fix - mini-tooltip render bug in Firefox

### DIFF
--- a/demos/scatter-plot.html
+++ b/demos/scatter-plot.html
@@ -10,6 +10,9 @@
             <div class="col-md-4 sidebar">
                 <h3>The code</h3>
                 <pre><code class="language-javascript">
+// add title to tooltip
+tooltip.title('Temperature (C)');
+
 scatterChart
     .aspectRatio(0.7)
     .width(containerWidth)
@@ -20,10 +23,7 @@ scatterChart
     .xAxisFormat('.1f')
     .yAxisFormat('$')
     .on('customMouseOver', tooltip.show)
-    .on('customMouseMove', function(dataPoint, mousePos, chartSize) {
-        tooltip.title('Temperature (C)');
-        tooltip.update(dataPoint, mousePos, chartSize);
-    })
+    .on('customMouseMove', tooltip.update)
     .on('customMouseOut', tooltip.hide);
 
 // tooltip set up
@@ -67,6 +67,7 @@ scatterChart
     .maxCircleArea(15)
     .on('customMouseOver', tooltip.show)
     .on('customMouseMove', function (dataPoint, mousePos, chartSize) {
+        // update tooltip title with changing data point name
         tooltip.title(dataPoint.name);
         // passing an empty object to not have any data
         // in the tooltip - we want to only show the title

--- a/demos/src/demo-scatter-plot.js
+++ b/demos/src/demo-scatter-plot.js
@@ -41,9 +41,7 @@ function createScatterPlotWithSingleSource(optionalColorSchema) {
             .yAxisFormat('$')
             .xAxisFormat('.1f')
             .on('customMouseOver', tooltip.show)
-            .on('customMouseMove', function (dataPoint, mousePos, chartSize) {
-                tooltip.update(dataPoint, mousePos, chartSize);
-            })
+            .on('customMouseMove', tooltip.update)
             .on('customMouseOut', tooltip.hide);
 
         if (optionalColorSchema) {

--- a/src/charts/mini-tooltip.js
+++ b/src/charts/mini-tooltip.js
@@ -174,7 +174,6 @@ define(function(require){
          * @return {Number}                 Max size of the lines
          */
         function getMaxLengthLine(...texts) {
-            console.log('texts', texts);
             let textSizes = texts.filter(x => !!x)
                 .map(x => x.node().getBBox().width);
 

--- a/src/charts/mini-tooltip.js
+++ b/src/charts/mini-tooltip.js
@@ -174,6 +174,7 @@ define(function(require){
          * @return {Number}                 Max size of the lines
          */
         function getMaxLengthLine(...texts) {
+            console.log('texts', texts);
             let textSizes = texts.filter(x => !!x)
                 .map(x => x.node().getBBox().width);
 
@@ -232,7 +233,7 @@ define(function(require){
          * @return {void}
          */
         function hideTooltip() {
-            svg.style('display', 'none');
+            svg.style('visibility', 'hidden');
         }
 
         /**
@@ -242,7 +243,7 @@ define(function(require){
          */
         function showTooltip(dataPoint) {
             updateContent(dataPoint);
-            svg.style('display', 'block');
+            svg.style('visibility', 'visible');
         }
 
         /**

--- a/test/specs/mini-tooltip.spec.js
+++ b/test/specs/mini-tooltip.spec.js
@@ -34,14 +34,14 @@ define(['jquery', 'd3', 'mini-tooltip'], function($, d3, tooltip) {
         });
 
         it('should not be visible by default', () =>  {
-            expect(containerFixture.select('.britechart-mini-tooltip').style('display')).toBe('none');
+            expect(containerFixture.select('.britechart-mini-tooltip').style('visibility')).toBe('hidden');
         });
 
         it('should be visible when required', () =>  {
-            expect(containerFixture.select('.britechart-mini-tooltip').style('display')).toBe('none');
+            expect(containerFixture.select('.britechart-mini-tooltip').style('visibility')).toBe('hidden');
             tooltipChart.show();
-            expect(containerFixture.select('.britechart-mini-tooltip').style('display')).not.toBe('none');
-            expect(containerFixture.select('.britechart-mini-tooltip').style('display')).toBe('block');
+            expect(containerFixture.select('.britechart-mini-tooltip').style('visibility')).not.toBe('hidden');
+            expect(containerFixture.select('.britechart-mini-tooltip').style('visibility')).toBe('visible');
         });
 
         xit('should resize the tooltip depending of number of topics', () =>  {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed the error of mini-tooltip throwing `NSERROR` and not rendering its content.

## Description
<!--- Describe your changes in detail -->
Instead of applying the styles `display: none` and `display: block`, we need to change `visibility` attribute instead. The visual behavior remains the same but the tooltip DOM node remains in the chart and hence error is not being thrown.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/eventbrite/britecharts/issues/596

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Revised the tests to test for `visibility` style attribute instead of `display`

## Screenshots (if appropriate):
<img width="1428" alt="screen shot 2018-04-18 at 3 38 58 am" src="https://user-images.githubusercontent.com/31934144/38927532-ebac57ec-42ba-11e8-8928-f614684cb1c0.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
