### PR TITLE
Give max space to stacked and grouped bars to remove tooltip not showing up

### DIFF
--- a/demos/kitchen-sink.html
+++ b/demos/kitchen-sink.html
@@ -52,13 +52,15 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-md-6">
+        <div class="col-md-12">
             <article>
                 <h2 class="tutorial__heading">Grouped Bar Chart with Tooltip</h2>
                 <div class="britechart js-grouped-bar-chart-tooltip-container card--chart"></div>
             </article>
         </div>
-        <div class="col-md-6">
+    </div>
+    <div class="row">
+        <div class="col-sm-12">
             <article>
                 <h2 class="tutorial__heading">Horizontal Stacked Bar Chart</h2>
                 <div class="britechart js-stacked-bar-chart-tooltip-container card--chart"></div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
After making stacked and grouped bars responsive, the tooltip did not show up for both. Set it back to take max space which resolves issue.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
