### PR TITLE
Fix - Swap drawing order of area and line for sparkline charts

### DIFF
--- a/demos/css/britecharts.css
+++ b/demos/css/britecharts.css
@@ -135,7 +135,7 @@
   stroke-linecap: round;
   stroke-linejoin: round; }
   .sparkline .line {
-    stroke-width: 4; }
+    stroke-width: 2; }
   .sparkline .sparkline-circle {
     fill: #ff584c;
     stroke-width: 0;

--- a/src/charts/sparkline.js
+++ b/src/charts/sparkline.js
@@ -78,6 +78,7 @@ define(function(require){
             areaGradientEl,
             areaGradientId = uniqueId('sparkline-area-gradient'),
 
+            lineStrokeWidth = 2,
             lineGradient = colorHelper.colorGradients.greenBlue,
             lineGradientEl,
             lineGradientId = uniqueId('sparkline-line-gradient'),
@@ -128,8 +129,8 @@ define(function(require){
                 buildSVG(this);
                 createGradients();
                 createMaskingClip();
-                drawLine();
                 drawArea();
+                drawLine();
                 drawEndMarker();
 
                 if (titleText) {
@@ -293,7 +294,7 @@ define(function(require){
 
             area = d3Shape.area()
                 .x(({date}) => xScale(date))
-                .y0(() => yScale(0))
+                .y0(() => yScale(0) + lineStrokeWidth / 2)
                 .y1(({value}) => yScale(value))
                 .curve(d3Shape.curveBasis);
 

--- a/src/styles/charts/sparkline.scss
+++ b/src/styles/charts/sparkline.scss
@@ -11,7 +11,7 @@ $dot-size: 0;
     stroke-linejoin: round;
 
     .line {
-        stroke-width: 4;
+        stroke-width: 2;
     }
 
     .sparkline-circle {


### PR DESCRIPTION
Fixes the bug that the sparkline chart's area interrupts the line rendering.

## Description
Swapped the drawing order of the chart's line and area. The line now overlays the area so the area no longer interrupts the line rendering. Additionally, the height of the area has been increased by `line-stroke-width / 2` so the line and area have the same bottom base line.

## Motivation and Context
#601 

## How Has This Been Tested?
Imho not needed.

## Screenshots (if appropriate):

Before:

![40166037-d851cfbe-59bd-11e8-9115-51b59c411f28](https://user-images.githubusercontent.com/20173900/40237052-99ccedb2-5aaf-11e8-8340-9dfc29820137.png)


After:

![screen shot 2018-05-18 at 15 02 29](https://user-images.githubusercontent.com/20173900/40237060-9da30a34-5aaf-11e8-80d4-5d895e9e904a.png)


## Types of changes
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
