### PR TITLE
Feature - Scatter Plot bounce on click animation

### DIFF
--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -704,21 +704,22 @@ define(function(require) {
         }
 
         /**
-         * Applies animation on datap point click
+         * Applies animation on data point click
+         * @param {Object} dataPoint
          * @return {void}
          * @private
          */
-        function handleClickAnimation(data) {
+        function handleClickAnimation(dataPoint) {
             highlightCircle
                 .transition()
                 .ease(ease)
                 .duration(100)
-                .attr('r', () => areaScale(data.y * 2))
+                .attr('r', () => areaScale(dataPoint.y * 2))
                 .transition()
                 .ease(ease)
                 .delay(50)
                 .duration(100)
-                .attr('r', () => areaScale(data.y));
+                .attr('r', () => areaScale(dataPoint.y));
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -695,7 +695,6 @@ define(function(require) {
          * @private
          */
         function handleClick(e) {
-            console.log('click')
             let { closestPoint } = getPointProps(e);
             let d = getPointData(closestPoint);
 
@@ -712,10 +711,14 @@ define(function(require) {
         function handleClickAnimation(data) {
             highlightCircle
                 .transition()
-                .delay(delay)
-                .duration(duration)
                 .ease(ease)
-                .attr('r', () => areaScale(data.y * 2));
+                .duration(100)
+                .attr('r', () => areaScale(data.y * 2))
+                .transition()
+                .ease(ease)
+                .delay(50)
+                .duration(100)
+                .attr('r', () => areaScale(data.y));
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -155,6 +155,8 @@ define(function(require) {
         ease = d3Ease.easeCircleIn,
         delay = 500,
         duration = 500,
+        clickDuration = 100,
+        clickDelay = 50,
 
         hasHollowCircles = false,
 
@@ -712,14 +714,14 @@ define(function(require) {
         function handleClickAnimation(dataPoint) {
             highlightCircle
                 .transition()
-                .ease(ease)
-                .duration(100)
-                .attr('r', () => areaScale(dataPoint.y * 2))
-                .transition()
-                .ease(ease)
-                .delay(50)
-                .duration(100)
-                .attr('r', () => areaScale(dataPoint.y));
+                  .ease(ease)
+                  .duration(clickDuration)
+                  .attr('r', () => areaScale(dataPoint.y * 2))
+                  .transition()
+                    .ease(ease)
+                    .delay(clickDelay)
+                    .duration(clickDuration)
+                    .attr('r', () => areaScale(dataPoint.y));
         }
 
         /**

--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -695,10 +695,27 @@ define(function(require) {
          * @private
          */
         function handleClick(e) {
+            console.log('click')
             let { closestPoint } = getPointProps(e);
             let d = getPointData(closestPoint);
 
+            handleClickAnimation(d);
+
             dispatcher.call('customClick', e, d, d3Selection.mouse(e), [chartWidth, chartHeight]);
+        }
+
+        /**
+         * Applies animation on datap point click
+         * @return {void}
+         * @private
+         */
+        function handleClickAnimation(data) {
+            highlightCircle
+                .transition()
+                .delay(delay)
+                .duration(duration)
+                .ease(ease)
+                .attr('r', () => areaScale(data.y * 2));
         }
 
         /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
On click, Scatter Plot's data point will bounce with animation. This adds a neat experience to the chart on different events. Applies the same `ease` function as on initial display.

**Note**: the animation effect looks much better than on GIF. For some reason it's not transitioned in the GIF.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Looks kind of cool

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visual test

## Screenshots (if appropriate):
![scatter-plot-click-bounce](https://user-images.githubusercontent.com/31934144/40352776-6e60967c-5db8-11e8-8a64-c1c18faa569d.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
