### PR TITLE
Fix - line chart demo if both brush extent range values are null

### DIFF
--- a/demos/src/demo-line.js
+++ b/demos/src/demo-line.js
@@ -23,7 +23,8 @@ function createBrushChart(optionalColorSchema) {
         brushMargin = {top:0, bottom: 40, left: 50, right: 30},
         brushContainer = d3Selection.select('.js-line-brush-chart-container'),
         containerWidth = brushContainer.node() ? brushContainer.node().getBoundingClientRect().width : false,
-        dataset;
+        dataset,
+        colorSchema = optionalColorSchema ? optionalColorSchema : null;
 
     if (containerWidth) {
         dataset = aTestDataSet().with5Topics().build();
@@ -41,7 +42,12 @@ function createBrushChart(optionalColorSchema) {
 
                 // Filter
                 d3Selection.selectAll('.js-line-chart-container .line-chart').remove();
-                createLineChart(optionalColorSchema ? optionalColorSchema : null, filterData(brushExtent[0], brushExtent[1]));
+
+                if (brushExtent[0] && brushExtent[1]) {
+                    createLineChart(colorSchema, filterData(brushExtent[0], brushExtent[1]));
+                } else {
+                    createLineChart(colorSchema, dataset);
+                }
             });
 
         brushContainer.datum(brushDataAdapter(dataset)).call(brushChart);

--- a/demos/src/demo-line.js
+++ b/demos/src/demo-line.js
@@ -23,8 +23,8 @@ function createBrushChart(optionalColorSchema) {
         brushMargin = {top:0, bottom: 40, left: 50, right: 30},
         brushContainer = d3Selection.select('.js-line-brush-chart-container'),
         containerWidth = brushContainer.node() ? brushContainer.node().getBoundingClientRect().width : false,
-        dataset,
-        colorSchema = optionalColorSchema ? optionalColorSchema : null;
+        colorSchema = optionalColorSchema ? optionalColorSchema : null,
+        dataset;
 
     if (containerWidth) {
         dataset = aTestDataSet().with5Topics().build();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If user just clicks on Brush, the values of brush extents on `customBrushEnd` would be null. In this case, the Line chart cannot convert `null` value to `datetime` value and hence throws errors. The fix was to just check for that case, and if this case happens apply the original dataset. See screenshots.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual

## Screenshots (if appropriate):
**Before:**
![demo-line-chart-brush-extent-before-fix](https://user-images.githubusercontent.com/31934144/40506939-117f37e4-5fa0-11e8-9c14-ef6e5b24ed46.gif)

**After:**
![demo-line-chart-brush-extent-fix](https://user-images.githubusercontent.com/31934144/40507150-2887177c-5fa0-11e8-9fea-bdc3cef6b1dd.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
