### PR TITLE
Fix - crosshair labels to be rendered on same level as lines

### DIFF
--- a/src/charts/scatter-plot.js
+++ b/src/charts/scatter-plot.js
@@ -573,14 +573,7 @@ define(function(require) {
          * @private
         */
         function drawDataPointsValueHighlights(data) {
-            removeDataPointsValueHighlights();
-
-            setCrossHairLinesStatus(1);
-
-            // initialize cross hair labels container
-            highlightCrossHairLabelsContainer = svg.select('.metadata-group')
-              .append('g')
-                .attr('class', 'crosshair-labels-container');
+            setCrossHairComponentStatus(1);
 
             // Draw line perpendicular to y-axis
             highlightCrossHairContainer.selectAll('line.highlight-y-line')
@@ -603,27 +596,21 @@ define(function(require) {
 
             // Draw data label for y value
             highlightCrossHairLabelsContainer.selectAll('text.highlight-y-legend')
-              .data([data])
-              .enter()
-                .append('text')
-                  .attr('text-anchor', 'middle')
-                  .attr('fill', ({name}) => nameColorMap[name])
-                  .attr('class', 'highlight-y-legend')
-                  .attr('y', (d) => (yScale(d.y) + (areaScale(d.y) / 2)))
-                  .attr('x', highlightTextLegendOffset)
-                  .text((d) => `${d3Format.format(yAxisFormat)(d.y)}`);
+              .attr('text-anchor', 'middle')
+              .attr('fill', nameColorMap[data.name])
+              .attr('class', 'highlight-y-legend')
+              .attr('y', (yScale(data.y) + (areaScale(data.y) / 2)))
+              .attr('x', highlightTextLegendOffset)
+              .text(`${d3Format.format(yAxisFormat)(data.y)}`);
 
             // Draw data label for x value
             highlightCrossHairLabelsContainer.selectAll('text.highlight-x-legend')
-              .data([data])
-              .enter()
-                .append('text')
-                  .attr('text-anchor', 'middle')
-                  .attr('fill', ({name}) => nameColorMap[name])
-                  .attr('class', 'highlight-x-legend')
-                  .attr('transform', `translate(0, ${chartHeight - highlightTextLegendOffset})`)
-                  .attr('x', (d) => (xScale(d.x) - (areaScale(d.y) / 2)))
-                  .text((d) => `${d3Format.format(xAxisFormat)(d.x)}`);
+              .attr('text-anchor', 'middle')
+              .attr('fill', nameColorMap[data.name])
+              .attr('class', 'highlight-x-legend')
+              .attr('transform', `translate(0, ${chartHeight - highlightTextLegendOffset})`)
+              .attr('x', (xScale(data.x) - (areaScale(data.y) / 2)))
+              .text(`${d3Format.format(xAxisFormat)(data.x)}`);
         }
 
         /**
@@ -774,10 +761,9 @@ define(function(require) {
          */
         function handleMouseOut(e, d) {
             removePointHighlight();
-            removeDataPointsValueHighlights();
 
             if (hasCrossHairs) {
-                setCrossHairLinesStatus(0);
+                setCrossHairComponentStatus(0);
             }
             dispatcher.call('customMouseOut', e, d, d3Selection.mouse(e));
         }
@@ -860,19 +846,36 @@ define(function(require) {
                 // initialize cross hair lines container
                 highlightCrossHairContainer = svg.select('.chart-group')
                   .append('g')
-                  .attr('class', 'crosshair-lines-container');
+                    .attr('class', 'crosshair-lines-container');
+
+                // initialize corss hair labels container
+                highlightCrossHairLabelsContainer = svg.select('.metadata-group')
+                  .append('g')
+                    .attr('class', 'crosshair-labels-container');
 
                 highlightCrossHairContainer.selectAll('line.highlight-y-line')
                   .data([1])
                   .enter()
-                    .append('line')
+                  .append('line')
                     .attr('class', 'highlight-y-line');
 
                 highlightCrossHairContainer.selectAll('line.highlight-x-line')
                   .data([1])
                   .enter()
-                    .append('line')
+                  .append('line')
                     .attr('class', 'highlight-x-line');
+
+                highlightCrossHairLabelsContainer.selectAll('text.highlight-y-legend')
+                  .data([1])
+                  .enter()
+                  .append('text')
+                      .attr('class', 'highlight-y-legend');
+
+                highlightCrossHairLabelsContainer.selectAll('text.highlight-x-legend')
+                  .data([1])
+                  .enter()
+                  .append('text')
+                    .attr('class', 'highlight-x-legend');
             }
         }
 
@@ -886,15 +889,6 @@ define(function(require) {
         }
 
         /**
-         * Removes the labels for the highlighted data point value
-         * @return {void}
-         * @private
-         */
-        function removeDataPointsValueHighlights() {
-            svg.selectAll('.crosshair-labels-container').remove();
-        }
-
-        /**
          * Sets the visibility of cross hair lines
          * if 1, it sets lines to visible,
          * if 0, it hides lines
@@ -902,8 +896,9 @@ define(function(require) {
          * @param {Number}
          * @private
          */
-        function setCrossHairLinesStatus(status = 0) {
+        function setCrossHairComponentStatus(status = 0) {
             highlightCrossHairContainer.attr('opacity', status);
+            highlightCrossHairLabelsContainer.attr('opacity', status);
         }
 
         // API

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -599,7 +599,7 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
                     expect(testYText).toEqual(expected);
                 });
 
-                it('crosshair labels with respect to x changes attributes', () => {
+                it('crosshair label with respect to x changes attributes', () => {
                     let container = containerFixture.select('svg');
                     let expectedFill = '#6aedc7';
 
@@ -612,7 +612,7 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
                     expect(scatterText).not.toHaveAttr('y');
                 });
 
-                it('crosshair text with respect to y changes attributes', () => {
+                it('crosshair label with respect to y changes attributes', () => {
                     let container = containerFixture.select('svg');
                     let expectedFill = '#6aedc7';
 

--- a/test/specs/scatter-plot.spec.js
+++ b/test/specs/scatter-plot.spec.js
@@ -546,7 +546,7 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
 
             describe('cross hair lines', () => {
 
-                it('successfully initialized with container on render', () => {
+                it('successfully initialize with container on render', () => {
                     let expected = 1;
                     let testContainer = containerFixture.select('.crosshair-lines-container').nodes().length;
                     let testXLine = containerFixture.select('line.highlight-x-line').nodes().length;
@@ -583,6 +583,46 @@ define(['d3', 'scatter-plot', 'scatterPlotDataBuilder'], function(d3, chart, dat
                     expect(scatterPoint).toHaveAttr('x2');
                     expect(scatterPoint).toHaveAttr('y1');
                     expect(scatterPoint).toHaveAttr('y2');
+                });
+            });
+
+            describe('crosshair labels', () => {
+
+                it('successfully initialize with container on render', () => {
+                    let expected = 1;
+                    let testContainer = containerFixture.select('.crosshair-labels-container').nodes().length;
+                    let testXText= containerFixture.select('text.highlight-x-legend').nodes().length;
+                    let testYText = containerFixture.select('text.highlight-y-legend').nodes().length;
+
+                    expect(testContainer).toEqual(expected);
+                    expect(testXText).toEqual(expected);
+                    expect(testYText).toEqual(expected);
+                });
+
+                it('crosshair labels with respect to x changes attributes', () => {
+                    let container = containerFixture.select('svg');
+                    let expectedFill = '#6aedc7';
+
+                    container.dispatch('mousemove');
+                    let scatterText = containerFixture.select('text.highlight-x-legend').node();
+
+                    expect(scatterText).toHaveAttr('fill', expectedFill);
+                    expect(scatterText).toHaveAttr('text-anchor');
+                    expect(scatterText).toHaveAttr('x');
+                    expect(scatterText).not.toHaveAttr('y');
+                });
+
+                it('crosshair text with respect to y changes attributes', () => {
+                    let container = containerFixture.select('svg');
+                    let expectedFill = '#6aedc7';
+
+                    container.dispatch('mousemove');
+                    let scatterText = containerFixture.select('text.highlight-y-legend').node();
+
+                    expect(scatterText).toHaveAttr('fill', expectedFill);
+                    expect(scatterText).toHaveAttr('text-anchor');
+                    expect(scatterText).toHaveAttr('x');
+                    expect(scatterText).toHaveAttr('y');
                 });
             });
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The way crosshair labels show up and disappear will be the same way as the crosshair lines. This should fix the bug when you hover over the crosshair labels that causes similar bug as lines had before.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added multiple DOM tests to `scatter-plot.spec.js`

## Screenshots (if appropriate):
Before:
![scatter-plot-crosshair-labels-before](https://user-images.githubusercontent.com/31934144/40745561-73e09b48-6460-11e8-9a9d-cbb3b2267c82.gif)

After:
![scatter-plot-crosshair-labels-fix](https://user-images.githubusercontent.com/31934144/40745565-75aa9c94-6460-11e8-9158-944435cd4f43.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
