### PR TITLE
Feat - Line chart data points highlight when all data shown

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -156,6 +156,7 @@ define(function(require){
             highlightCircleSize = 12,
             highlightCircleRadius = 5,
             highlightCircleStroke = 2,
+            highlightCircleStrokeAll = 5,
             highlightCircleActiveRadius = highlightCircleRadius + 2,
             highlightCircleActiveStrokeWidth = 5,
             highlightCircleActiveStrokeOpacity = 0.6,
@@ -942,7 +943,9 @@ define(function(require){
                                     .attr('cx', highlightCircleSize)
                                     .attr('cy', 0)
                                     .attr('r', highlightCircleRadius)
-                                    .style('stroke-width', highlightCircleStroke)
+                                    .style('stroke-width', () => (
+                                        shouldShowAllDataPoints ? highlightCircleStrokeAll : highlightCircleStroke
+                                    ))
                                     .style('stroke', topicColorMap[d.name])
                                     .style('cursor', 'pointer')
                                     .on('click', function () {
@@ -952,7 +955,6 @@ define(function(require){
                                     .on('mouseout', function () {
                                         removeFilter(this);
                                     });
-
 
                 const path = topicsWithNode[index].node;
                 const x = xScale(new Date(dataPoint.topics[index].date));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When `shouldHighlightAllDataPoints` is true, there needs to be a way to distinguish hovered points to be highlighted with some property change. The `stroke-width` seems to be reasonable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better experience

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Visual test

## Screenshots (if appropriate):
![line-chart-points-highlights-after](https://user-images.githubusercontent.com/31934144/41900625-0027c292-78e4-11e8-83f8-4b5456226d46.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
