### PR TITLE
Fix - Stacked bar chart not rendering all bars when `isAnimated(true)`

### DIFF
--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -130,8 +130,8 @@ define(function(require){
             barOpacity = 0.24,
 
             animationDelayStep = 20,
-            animationDelays = d3Array.range(animationDelayStep, maxBarNumber* animationDelayStep, animationDelayStep),
             animationDuration = 1000,
+            animationDelays,
 
             grid = null,
 
@@ -570,6 +570,8 @@ define(function(require){
             }
 
             let series = svg.select('.chart-group').selectAll('.layer')
+
+            animationDelays = d3Array.range(animationDelayStep, (layers[0].length + 1) * animationDelayStep, animationDelayStep)
 
             if (isHorizontal) {
                 drawHorizontalBars(series)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This is a fix for #624 

## Description

The var `animationDelays` is not being set dynamically based on the input dataset: it always generates an array for 7 bars.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
