### PR TITLE
Fix - set grouped bar animationDelays range based on number of layers

### DIFF
--- a/src/charts/grouped-bar.js
+++ b/src/charts/grouped-bar.js
@@ -581,7 +581,7 @@ define(function (require) {
 
             let series = svg.select('.chart-group').selectAll('.layer');
 
-            animationDelays = d3Array.range(animationDelayStep, (layers[0].length + 1) * animationDelayStep, animationDelayStep)
+            animationDelays = d3Array.range(animationDelayStep, (layers.length + 1) * animationDelayStep, animationDelayStep)
             if (isHorizontal) {
                 drawHorizontalBars(series);
             } else {

--- a/test/specs/grouped-bar.spec.js
+++ b/test/specs/grouped-bar.spec.js
@@ -359,7 +359,7 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
         });
 
         describe('when margins are set partially', function() {
-            
+
             it('should override the default values', () => {
                 let previous = groupedBarChart.margin(),
                 expected = {
@@ -375,7 +375,7 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
                 expect(previous).not.toBe(actual);
                 expect(actual).toEqual(expected);
             })
-        });  
+        });
 
         describe('when clicking on a bar', () => {
 
@@ -416,5 +416,21 @@ define(['d3', 'grouped-bar', 'groupedBarChartDataBuilder'], function(d3, chart, 
             });
         });
 
+
+        describe('when grouped bar is animated', () => {
+
+            it('it renders correct number of layers and bars', () => {
+                const expectedNLayers = 4;
+                const nBarsPerLayer = 3;
+                const actualNLayers = containerFixture.selectAll('.chart-group .layer').nodes().length;
+                const actualNBars = containerFixture.selectAll('.chart-group .bar').nodes().length;
+
+                groupedBarChart.isAnimated(true);
+                containerFixture.datum(dataset.data).call(groupedBarChart);
+
+                expect(actualNLayers).toEqual(expectedNLayers);
+                expect(actualNBars).toEqual(expectedNLayers * nBarsPerLayer);
+            });
+        });
     });
 });

--- a/test/specs/stacked-bar.spec.js
+++ b/test/specs/stacked-bar.spec.js
@@ -406,7 +406,7 @@ define(['d3', 'stacked-bar', 'stackedBarDataBuilder'], function(d3, chart, dataB
         });
 
         describe('when margins are set partially', function() {
-            
+
             it('should override the default values', () => {
                 let previous = stackedBarChart.margin(),
                 expected = {
@@ -422,7 +422,7 @@ define(['d3', 'stacked-bar', 'stackedBarDataBuilder'], function(d3, chart, dataB
                 expect(previous).not.toBe(actual);
                 expect(actual).toEqual(expected);
             })
-        });  
+        });
 
         describe('when hovering', function() {
 
@@ -446,6 +446,22 @@ define(['d3', 'stacked-bar', 'stackedBarDataBuilder'], function(d3, chart, dataB
 
                 expect(callbackSpy.calls.count()).toBe(1);
                 expect(callbackSpy.calls.allArgs()[0].length).toBe(2);
+            });
+        });
+
+        describe('when stacked bar is animated', () => {
+
+            it('it renders correct number of layers and bars', () => {
+                const expectedNLayers = 3;
+                const nBarsPerLayer = 4;
+                const actualNLayers = containerFixture.selectAll('.chart-group .layer').nodes().length;
+                const actualNBars = containerFixture.selectAll('.chart-group .bar').nodes().length;
+
+                stackedBarChart.isAnimated(true);
+                containerFixture.datum(dataset.data).call(stackedBarChart);
+
+                expect(actualNLayers).toEqual(expectedNLayers);
+                expect(actualNBars).toEqual(expectedNLayers * nBarsPerLayer);
             });
         });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The animated grouped bar charts stopped being rendered due to recent change that attempted to fix the other bug. The problem was that in Grouped Bar the data layer object shape is different. The number of layers is what needs to be calculated for `animationDelays`.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes bug caused by recent changes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added two tests, for grouped and stacked bars each, to test if correct number of layers and bars are rendered when `isAnimated` property is set to `true`.

## Screenshots (if appropriate):
**Before:**
<img width="881" alt="screen shot 2018-07-14 at 11 59 30 pm" src="https://user-images.githubusercontent.com/31934144/42731427-fa9e0bf0-87c1-11e8-88aa-65590ee21677.png">

**After:**
![grouped-bar-layer-animated-fix](https://user-images.githubusercontent.com/31934144/42731424-e3c74284-87c1-11e8-92ac-b68f670acd56.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
