### PR TITLE
Feature - apply colorSchema data to bullet charts and add to demo

### DIFF
--- a/demos/bullet.html
+++ b/demos/bullet.html
@@ -22,6 +22,9 @@ dataset.forEach(data => {
     bulletContainer.datum(data).call(bulletChart);
 });
                 </code></pre>
+                <h4>Colors</h4>
+                <label class="control-label">You can also check other color schemas:</label>
+                <div class="js-color-selector-container"></div>
                 <h4>Data Input</h4>
                 <p>Check the <a href="/britecharts/global.html#BulletChartData__anchor">data input schema</a> of this chart.</p>
                 <h4>Export Chart</h4>

--- a/demos/src/demo-bullet.js
+++ b/demos/src/demo-bullet.js
@@ -6,9 +6,12 @@ const PubSub = require('pubsub-js');
 const bullet = require('./../../src/charts/bullet');
 const dataBuilder = require('./../../test/fixtures/bulletChartDataBuilder');
 
+const colorSelectorHelper = require('./helpers/colorSelector');
+const colors = require('./../../src/charts/helpers/color');
+
 require('./helpers/resizeHelper');
 
-function createBulletChart() {
+function createBulletChart(optionalColorSchema) {
     const testDataSet = new dataBuilder.BulletChartDataBuilder();
     const bulletContainer = d3Selection.select('.js-bullet-chart-container');
     const containerWidth = bulletContainer.node()
@@ -26,6 +29,11 @@ function createBulletChart() {
         dataset.forEach(data => {
             bulletChart = new bullet();
             bulletChart.width(containerWidth);
+
+            if (optionalColorSchema) {
+                bulletChart.colorSchema(optionalColorSchema);
+            }
+
             bulletContainer.datum(data).call(bulletChart);
         });
     }
@@ -43,4 +51,9 @@ if (d3Selection.select('.js-bullet-chart-container').node()) {
 
     // Redraw charts on window resize
     PubSub.subscribe('resize', redrawCharts);
+
+    // Color schema selector
+    colorSelectorHelper.createColorSelector('.js-color-selector-container', '.bullet-chart', function (newSchema) {
+        createBulletChart(newSchema);
+    });
 }

--- a/src/charts/bullet.js
+++ b/src/charts/bullet.js
@@ -197,7 +197,7 @@ define(function(require) {
             rangeOpacityScale = ranges.map((d, i) => startMaxRangeOpacity - (i * rangeOpacifyDiff)).reverse();
             measureOpacityScale = ranges.map((d, i) => 0.9 - (i * measureOpacifyDiff)).reverse();
 
-            // initialize measure bar colors
+            // initialize measure bar and marker line colors
             measureColor = colorSchema[1];
         }
 

--- a/src/charts/bullet.js
+++ b/src/charts/bullet.js
@@ -71,6 +71,7 @@ define(function(require) {
             measureOpacifyDiff = 0.3,
 
             colorSchema = colorHelper.colorSchemas.britecharts,
+            rangeColor,
             measureColor,
             numberFormat = '',
 
@@ -197,7 +198,8 @@ define(function(require) {
             rangeOpacityScale = ranges.map((d, i) => startMaxRangeOpacity - (i * rangeOpacifyDiff)).reverse();
             measureOpacityScale = ranges.map((d, i) => 0.9 - (i * measureOpacifyDiff)).reverse();
 
-            // initialize measure bar and marker line colors
+            // initialize range and measure bars and marker line colors
+            rangeColor = colorSchema[0];
             measureColor = colorSchema[1];
         }
 
@@ -289,7 +291,7 @@ define(function(require) {
               .data(ranges)
               .enter()
                 .append('rect')
-                  .attr('fill', colorSchema[0])
+                  .attr('fill', rangeColor)
                   .attr('opacity', (d, i) => rangeOpacityScale[i])
                   .attr('class', (d, i) => `range r${i}`)
                   .attr('width', barWidth)

--- a/src/charts/bullet.js
+++ b/src/charts/bullet.js
@@ -70,8 +70,8 @@ define(function(require) {
             measureOpacityScale,
             measureOpacifyDiff = 0.3,
 
-            colorSchema = colorHelper.singleColors.aloeGreen,
-            measureColor = colorHelper.colorSchemas.green[5],
+            colorSchema = colorHelper.colorSchemas.britecharts,
+            measureColor,
             numberFormat = '',
 
             baseLine,
@@ -196,6 +196,9 @@ define(function(require) {
             // set up opacity scale based on ranges and measures
             rangeOpacityScale = ranges.map((d, i) => startMaxRangeOpacity - (i * rangeOpacifyDiff)).reverse();
             measureOpacityScale = ranges.map((d, i) => 0.9 - (i * measureOpacifyDiff)).reverse();
+
+            // initialize measure bar colors
+            measureColor = colorSchema[1];
         }
 
         /**

--- a/src/charts/bullet.js
+++ b/src/charts/bullet.js
@@ -409,7 +409,9 @@ define(function(require) {
         };
 
         /**
-         * Gets or Sets the colorSchema of the chart
+         * Gets or Sets the colorSchema of the chart.
+         * The first color from the array will be applied to range bars (the wider bars).
+         * The second color from the array will be applied to measure bars (the narrow bars) and marker lines.
          * @param  {String[]} _x        Desired colorSchema for the graph
          * @return {String[] | module}  Current colorSchema or Chart module to chain calls
          * @public

--- a/test/specs/bullet.spec.js
+++ b/test/specs/bullet.spec.js
@@ -334,5 +334,25 @@ define(['d3', 'bullet', 'bulletChartDataBuilder'], function(d3, chart, dataBuild
                 });
             });
         });
+
+        describe('when custom colorSchema is passed', () => {
+
+            it('should assign first two indexed colors for range and measure/markers in order', () => {
+                const expectedRangeColor = '#bbb';
+                const expectedMeasureColor = '#ccc';
+                const expectedMarkerColor = expectedMeasureColor;
+
+                bulletChart.colorSchema([expectedRangeColor, expectedMeasureColor]);
+                containerFixture.datum(dataset[1]).call(bulletChart);
+
+                const rangeBar = containerFixture.selectAll('rect.range').node();
+                const measureBar = containerFixture.selectAll('rect.measure').node();
+                const markerLine = containerFixture.selectAll('line.marker-line').node();
+
+                expect(rangeBar).toHaveAttr('fill', expectedRangeColor);
+                expect(measureBar).toHaveAttr('fill', expectedMeasureColor);
+                expect(markerLine).toHaveAttr('stroke', expectedMarkerColor);
+            });
+        });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Applied `colorSchema` array (index 0 and 1 colors) to measure and range bars as well as the marker lines. Range bars will have the lighter color (`colorSchema[0]`) while measure bars and marker lines will have the darker color (`colorSchema[1]`) from the theme. Measure bars and marker lines have the same color, the measure bars vary with opacity, however.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So that people can change color schema.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a DOM test that verifies that `colorSchema` list of colors is applied accordingly.

## Screenshots (if appropriate):
**Demo:**
![bullet-chart-color-schema](https://user-images.githubusercontent.com/31934144/42732876-fa18788e-87dd-11e8-80da-fddacc17e589.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
