### PR TITLE
implemented excludeMutedEvents chart option

### DIFF
--- a/src/charts/stacked-bar.js
+++ b/src/charts/stacked-bar.js
@@ -114,6 +114,7 @@ define(function(require){
             hasReversedStacks = false,
 
             tooltipThreshold = 480,
+            excludeMutedEvents = [],
 
             yAxisLabel,
             yAxisLabelEl,
@@ -198,6 +199,23 @@ define(function(require){
                     .on('click',  function(d) {
                         handleClick(this, d);
                     });
+            } else {
+                for (let i = 0; i < excludeMutedEvents.length; i++) {
+
+                    let eventName = excludeMutedEvents[i];
+
+                    svg.on(eventName, function(d) {
+                        if (eventName === 'mouseover') {
+                            handleMouseOver(this, d);
+                        } else if (eventName === 'mouseout') {
+                            handleMouseOut(this, d);
+                        } else if (eventName === 'mousevove') {
+                            handleMouseMove(this, d);
+                        } else if (eventName === 'click') {
+                            handleClick(this, d);
+                        }
+                    })
+                }
             }
 
             svg.selectAll('.bar')
@@ -1141,6 +1159,25 @@ define(function(require){
 
             return this;
         };
+
+        /**
+         * Excludes the given events from being muted when tooltipThreshold is reached.
+         * For example, if ['click'] is provided, the onclick events will be fired
+         * regardless of whether width > tooltipThreshold
+         *
+         * @param {String[]} List of events to exclude from being muted
+         * @return {String[] | modelu} Current excludeMutedEvents or Chart module to chain calls
+         * @public
+         *
+         */
+        exports.excludeMutedEvents = function(_x) {
+            if (!arguments.length) {
+                return excludeMutedEvents;
+            }
+            excludeMutedEvents = _x;
+
+            return this;
+        }
 
         /**
          * Gets or Sets the valueLabel of the chart


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a chart option name `excludeMutedEvents` which will exclude the given events from being muted in cases where the tooltip is hidden because `tooltipThreshold` is reached.

## Motivation and Context
I'm working on an application where I still need access to the *onclick* event even when the tooltip is hidden (because width > `tooltipThreshold`. By providing a list of excluded events, the user can customize the behavior of exactly which events are muted.

## Screenshots:
![image](https://user-images.githubusercontent.com/8518288/43015984-e53f1ae8-8c16-11e8-8c8e-ed9553a4ff46.png)


## Types of changes
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
