### PR TITLE
IE 11 export chart fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "homepage": "http://eventbrite.github.io/britecharts/",
   "dependencies": {
     "base-64": "^0.1.0",
+    "canvg-browser": "^1.0.0",
     "d3": "^5.0.0",
     "lodash.assign": "^4.2.0"
   },
@@ -129,8 +130,8 @@
     "webpack": "^3.6.0",
     "webpack-bundle-analyzer": "^2.9.0",
     "webpack-dev-server": "^2.9.1",
-    "webpack-merge": "^4.1.1",
     "webpack-livereload-plugin": "^0.9.0",
+    "webpack-merge": "^4.1.1",
     "yargs": "^8.0.2"
   }
 }

--- a/src/charts/helpers/export.js
+++ b/src/charts/helpers/export.js
@@ -1,6 +1,6 @@
 define(function(require) {
     'use strict';
-
+    const canvg = require('canvg-browser');
     const {colorSchemas} = require('./color');
     const constants = require('./constants');
     const serializeWithStyles = require('./style');
@@ -41,13 +41,25 @@ define(function(require) {
      * @param  {string} title       Title for the image
      */
     function exportChart(d3svg, filename, title) {
-        let img = createImage(convertSvgToHtml.call(this, d3svg, title));
+        let svgHtml = convertSvgToHtml.call(this, d3svg, title);
+        let canvas = createCanvas(this.width(), this.height());
 
-        img.onload = handleImageLoad.bind(
+        if(navigator.msSaveOrOpenBlob){
+            let options = {
+                log: false,
+                ignoreMouse: true
+            };
+
+            canvg(canvas, svgHtml, options);
+            return(navigator.msSaveOrOpenBlob && navigator.msSaveOrOpenBlob(canvas.msToBlob(), filename));
+        } else {
+            let img = createImage( svgHtml );
+            img.onload = handleImageLoad.bind(
                 img,
-                createCanvas(this.width(), this.height()),
+                canvas,
                 filename
             );
+        }
     }
 
     /**

--- a/src/charts/helpers/style.js
+++ b/src/charts/helpers/style.js
@@ -96,7 +96,7 @@ module.exports = (function() {
                 });
 
                 // fix for IE 11 not supporting svg.outerHTML
-                result = $('<div>').append($(elem).clone()).html();
+                result = new XMLSerializer().serializeToString(elem);
 
                 elements = [].map.call(elements, (el, i) => {
                     el.style.cssText = cssTexts[i];

--- a/src/charts/helpers/style.js
+++ b/src/charts/helpers/style.js
@@ -95,7 +95,9 @@ module.exports = (function() {
                     }
                 });
 
-                result = elem.outerHTML;
+                // fix for IE 11 not supporting svg.outerHTML
+                result = $('<div>').append($(elem).clone()).html();
+
                 elements = [].map.call(elements, (el, i) => {
                     el.style.cssText = cssTexts[i];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1383,6 +1383,14 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000713"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000713.tgz#ea01761840b5f148faf94ec5f34d0aa1d321966f"
 
+canvg-browser@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/canvg-browser/-/canvg-browser-1.0.0.tgz#c63cb5a9e7a0c70698a9c87783473e60915ea483"
+  dependencies:
+    rgbcolor "0.0.4"
+    stackblur "^1.0.0"
+    xmldom "^0.1.22"
+
 cardinal@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cardinal/-/cardinal-0.4.0.tgz#7d10aafb20837bde043c45e43a0c8c28cdaae45e"
@@ -6528,6 +6536,10 @@ retry@0.6.0, retry@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.6.0.tgz#1c010713279a6fd1e8def28af0c3ff1871caa537"
 
+rgbcolor@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/rgbcolor/-/rgbcolor-0.0.4.tgz#ca04615a2d03eb61e49f2a75f239a46fb77d8b1d"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -6990,6 +7002,10 @@ sshpk@^1.7.0:
     ecc-jsbn "~0.1.1"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+stackblur@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stackblur/-/stackblur-1.0.0.tgz#b407a7e05c93b08d66883bb808d7cba3a503f12f"
 
 statuses@1, "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
@@ -7820,6 +7836,10 @@ xdg-basedir@^1.0.0:
 xmlcreate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-1.0.2.tgz#fa6bf762a60a413fb3dd8f4b03c5b269238d308f"
+
+xmldom@^0.1.22:
+  version "0.1.27"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
 
 xmlhttprequest-ssl@1.5.3:
   version "1.5.3"


### PR DESCRIPTION
## Description
this PR addresses:https://github.com/eventbrite/britecharts/issues/648
the changes provide a workaround and fixes for IE 11 not being able to handle SVG exports.

## Motivation and Context
Allows users to download SVGs

related links:
https://stackoverflow.com/questions/12592417/outerhtml-of-an-svg-element

I found that svg.outerHTML was failing, and I added a polyfill, but that would still throw a security error when you try to run the .toDataURL() method on an image.
https://stackoverflow.com/questions/20322745/ie-throws-security-error-when-calling-todataurl-on-canvas

I researched the issues and possible ways to fix the svg download issue in ie and found a few examples that recommended using fabric.js.

This was the easiest and cleanest solution that I found:
https://willkoehler.net/2014/11/07/client-side-solution-for-downloading-highcharts-charts-as-images.html

http://jsfiddle.net/willkoehler/vushe780/

## How Has This Been Tested?
I built the demos and tested the Export button to download a chart.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
