### PR TITLE
fix for IE 11 tooltip text going out of box

### DIFF
--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -82,7 +82,7 @@ define(function(require){
             tooltipBorderRadius = 3,
             ttTextX = 0,
             ttTextY = 37,
-            textSize,
+            textHeight,
             entryLineLimit = 3,
             initialTooltipTextXPosition = -25,
             tooltipTextLinePadding = 5,
@@ -322,7 +322,6 @@ define(function(require){
          */
         function updateTopicContent(topic){
             let name = topic[nameLabel],
-                textHeight,
                 tooltipRight,
                 tooltipLeftText,
                 tooltipRightText,
@@ -350,12 +349,10 @@ define(function(require){
                 .style('fill', tooltipTextColor)
                 .text(tooltipRightText);
 
-            textSize = elementText.node().getBBox();
-
             // IE11 give us sometimes a height of 0 when hovering on top of the vertical marker
             // This hack fixes it for some cases, but it doesn't work in multiline (they won't wrap)
             // Let's remove this once we stop supporting IE11
-            textHeight = textSize.height ? textSize.height : 18.4;
+            textHeight = elementText.node().getBBox().height ? elementText.node().getBBox().height : textHeight;
 
             tooltipHeight += textHeight + tooltipTextLinePadding;
             // update the width if it exists because IE renders the elements

--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -86,7 +86,7 @@ define(function(require){
             entryLineLimit = 3,
             initialTooltipTextXPosition = -25,
             tooltipTextLinePadding = 5,
-
+            tooltipRightWidth,
             // Animations
             mouseChaseDuration = 100,
             ease = d3Ease.easeQuadInOut,
@@ -358,9 +358,10 @@ define(function(require){
             textHeight = textSize.height ? textSize.height : 18.4;
 
             tooltipHeight += textHeight + tooltipTextLinePadding;
-
-            // Not sure if necessary
-            tooltipRight.attr('x', tooltipWidth - tooltipRight.node().getBBox().width - 10 - tooltipWidth / 4)
+            // update the width if it exists because IE renders the elements
+            // too slow and cant figure out the width?
+            tooltipRightWidth = tooltipRight.node().getBBox().width ? tooltipRight.node().getBBox().width : tooltipRightWidth;
+            tooltipRight.attr( 'x', tooltipWidth - tooltipRightWidth - 10 - tooltipWidth / 4 );
 
             tooltipBody
                 .append('circle')

--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -528,7 +528,17 @@ define(function(require){
                     line.push(word);
                     tspan.text(line.join(' '));
 
-                    if (tspan.node().getComputedTextLength() > width) {
+                    // fixes for IE wrap text issue
+                    let temp;
+                    temp = document.createElementNS("http://www.w3.org/2000/svg","text");
+                    temp.appendChild(document.createTextNode(line.join(' ')));
+                    temp.setAttribute('id', 'tempnode');
+                    temp.setAttribute("x",38);
+                    temp.setAttribute("y",18);
+                    document.getElementsByTagName("svg")[0].appendChild(temp);
+                    const textWidth = document.getElementsByTagName("svg")[0].lastChild.getBBox().width;
+
+                    if (textWidth > width) {
                         line.pop();
                         tspan.text(line.join(' '));
 
@@ -541,8 +551,11 @@ define(function(require){
                                 .text(word);
                         }
                     }
+
+                    temp.parentNode.removeChild(temp);
                 }
             });
+
         }
 
         /**

--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -543,8 +543,6 @@ define(function(require){
                                 .text(word);
                         }
                     }
-
-                    // temp.parentNode.removeChild(temp);
                 }
             });
 

--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -14,6 +14,8 @@ define(function(require){
         isInteger
     } = require('./helpers/number');
 
+    const {getTextWidth} = require('./helpers/text');
+
     /**
      * Tooltip Component reusable API class that renders a
      * simple and configurable tooltip element for Britechart's
@@ -526,14 +528,7 @@ define(function(require){
                     tspan.text(line.join(' '));
 
                     // fixes for IE wrap text issue
-                    let temp;
-                    temp = document.createElementNS("http://www.w3.org/2000/svg","text");
-                    temp.appendChild(document.createTextNode(line.join(' ')));
-                    temp.setAttribute('id', 'tempnode');
-                    temp.setAttribute("x",38);
-                    temp.setAttribute("y",18);
-                    document.getElementsByTagName("svg")[0].appendChild(temp);
-                    const textWidth = document.getElementsByTagName("svg")[0].lastChild.getBBox().width;
+                    const textWidth = getTextWidth(line.join(' '), 16, 'Karla, sans-serif');
 
                     if (textWidth > width) {
                         line.pop();
@@ -549,7 +544,7 @@ define(function(require){
                         }
                     }
 
-                    temp.parentNode.removeChild(temp);
+                    // temp.parentNode.removeChild(temp);
                 }
             });
 


### PR DESCRIPTION
## Description
In IE, it appears that it doesn't always get the rendered node width.  It looks like there is some sort of lag for the element to get drawn and width calculated.

## Motivation and Context
This fix saves the tooltipRight width and updates it if it is found. 
link to issue: https://github.com/eventbrite/britecharts/issues/650

## How Has This Been Tested?
I made the change and tested it in a virtualbox image running windows 7 and IE 11
the right side text does appear a bit off sometimes, but its better than having it run outside of the box.

The long text titles is still having issues and doesn't wrap all the time.  i think it's the same issue.
https://github.com/eventbrite/britecharts/blob/master/src/charts/tooltip.js#L530

## Screenshots (if appropriate):
sometimes the text appears left or right justified
<img width="501" alt="screen shot 2018-08-06 at 2 22 47 pm" src="https://user-images.githubusercontent.com/1038306/43733951-46ac1a40-9984-11e8-95a6-3377a61e52be.png">
<img width="616" alt="screen shot 2018-08-06 at 2 23 11 pm" src="https://user-images.githubusercontent.com/1038306/43733954-497d9a5a-9984-11e8-845e-e4d9a9128f41.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
