### PR TITLE
Moved the merge() command in line.drawLines()

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -652,17 +652,17 @@ define(function(require){
             lines = svg.select('.chart-group').selectAll('.line')
                 .data(dataByTopic, getTopic);
 
-            paths = lines.merge(lines.enter()
+            paths = lines.enter()
               .append('g')
                 .attr('class', 'topic')
               .append('path')
                 .attr('class', 'line')
+                .merge(lines)
                 .attr('id', ({topic}) => topic)
                 .attr('d', ({dates}) => topicLine(dates))
                 .style('stroke', (d) => (
                     dataByTopic.length === 1 ? `url(#${lineGradientId})` : getLineColor(d)
-                ))
-            );
+                ));
 
             lines
                 .exit()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The d3.merge() has been moved in the drawLines() method to be after enter() on the method chain, instead of having it wrap around the d3.enter() method call.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
https://github.com/eventbrite/britecharts/issues/606

With the merge statement as it currently is, existing path nodes do not have their d attribute updated when refreshing the graph (for either responsiveness, or in my case, real-time line chart data).

By moving the .merge() command after the enter() it means any data updates to values, axis, or topics gets applies to the line properly upon refreshing the graph using .call() on the container.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've ran all the yarn tests and they came back successfully.
I've tested this with refreshing multi-line and single line charts, it works correctly now.

I'm currently using this fix in a dashboard for a work project.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
