### PR TITLE
Changed handeMouseOut to use computeColor instead of colorMap

### DIFF
--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -110,7 +110,14 @@ define(function(require) {
             animationStepRatio = 70,
             interBarDelay = (d, i) => animationStepRatio * i,
 
-            highlightBarFunction = (barSelection) => barSelection.attr('fill', ({name}) => d3Color.color(colorMap(name)).darker()),
+            highlightBarFunction = (barSelection) => 
+                barSelection.attr('fill', ({name}) => 
+                    d3Color.color(
+                        chartGradientColors 
+                        ? chartGradientColors[1]
+                        : colorMap(name)
+                    ).darker()
+                ),
             orderingFunction,
 
             valueLabel = 'value',

--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -776,7 +776,7 @@ define(function(require) {
             dispatcher.call('customMouseOut', e, d, d3Selection.mouse(e), [chartWidth, chartHeight]);
 
             barList.forEach((barRect) => {
-                d3Selection.select(barRect).attr('fill', ({name}) => colorMap(name));
+                d3Selection.select(barRect).attr('fill', ({name}) => computeColor(name));
             });
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I've changed handleMouseOut in bar.js so it uses computeColor to determine the fill attribute instead of colorMap, to bring it in line with all the other .attr('fill', x) method calls in the .js file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jsbin.com/pawuxoruti/1/edit?html,js,output

When using a gradient on a bar chart, if you hover over the chart it'll remove the gradient.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I've ran all yarn tests, and I'm also using this patch in production.
It's a very minor change, very unlikely to break anything.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
