### PR TITLE
Fix - Take into account xTicks/yTicks settings when drawing grid lines on the bar chart

### DIFF
--- a/src/charts/bar.js
+++ b/src/charts/bar.js
@@ -683,7 +683,7 @@ define(function(require) {
         function drawHorizontalGridLines() {
             maskGridLines = svg.select('.grid-lines-group')
                 .selectAll('line.vertical-grid-line')
-                .data(xScale.ticks(4))
+                .data(xScale.ticks(xTicks).slice(1))
                 .enter()
                   .append('line')
                     .attr('class', 'vertical-grid-line')
@@ -719,7 +719,7 @@ define(function(require) {
         function drawVerticalGridLines() {
             maskGridLines = svg.select('.grid-lines-group')
                 .selectAll('line.horizontal-grid-line')
-                .data(yScale.ticks(4))
+                .data(yScale.ticks(yTicks).slice(1))
                 .enter()
                   .append('line')
                     .attr('class', 'horizontal-grid-line')


### PR DESCRIPTION
## Description
Currently the bar chart has the number of horizontal/vertical grid lines to draw hardcoded to 4 which means they are often out of alignment with the axis values ([example](https://codepen.io/anon/pen/gBgdRp)). There are also multiple lines being drawn in the same place (e.g. the `.extended-y-line` line in the example above is drawn on top of the first `.vertical-grid-line`). This PR updates the behaviour of the bar chart to be the same as the grouped and stacked bar charts.

## Motivation and Context
Consistency in the drawing of the grid lines between bar, grouped bar and stacked bar charts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Manually tested charts locally
* I couldn't spot any tests for number of grid lines drawn in the grouped and stacked bar tests so haven't added one for this change - if that's a problem let me know and i'll fix :)
* Ran the test suite

## Screenshots:
Before:
<img width="548" alt="before" src="https://user-images.githubusercontent.com/387478/46723556-09f11c80-cc70-11e8-84f7-3c50d44fa8bc.png">

After:
<img width="549" alt="after" src="https://user-images.githubusercontent.com/387478/46723632-30af5300-cc70-11e8-8e65-a27c592d5a0d.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
