### PR TITLE
Fix - tooltip render error in firefox

### DIFF
--- a/src/charts/tooltip.js
+++ b/src/charts/tooltip.js
@@ -163,7 +163,7 @@ define(function(require){
                 svg = d3Selection.select(container)
                   .append('g')
                     .classed('britechart britechart-tooltip', true)
-                    .style('display', 'none');
+                    .style('visibility', 'hidden');
 
                 buildContainerGroups();
                 drawTooltip();
@@ -647,7 +647,7 @@ define(function(require){
          * @public
          */
         exports.hide = function() {
-            svg.style('display', 'none');
+            svg.style('visibility', 'hidden');
 
             return this;
         };
@@ -735,7 +735,7 @@ define(function(require){
          * @public
          */
         exports.show = function() {
-            svg.style('display', 'block');
+            svg.style('visibility', 'visible');
 
             return this;
         };

--- a/test/specs/tooltip.spec.js
+++ b/test/specs/tooltip.spec.js
@@ -36,14 +36,14 @@ define(['jquery', 'd3', 'tooltip'], function($, d3, tooltip) {
         });
 
         it('should not be visible by default', () =>  {
-            expect(containerFixture.select('.britechart-tooltip').style('display')).toBe('none');
+            expect(containerFixture.select('.britechart-tooltip').style('visibility')).toBe('hidden');
         });
 
         it('should be visible when required', () =>  {
-            expect(containerFixture.select('.britechart-tooltip').style('display')).toBe('none');
+            expect(containerFixture.select('.britechart-tooltip').style('visibility')).toBe('hidden');
             tooltipChart.show();
-            expect(containerFixture.select('.britechart-tooltip').style('display')).not.toBe('none');
-            expect(containerFixture.select('.britechart-tooltip').style('display')).toBe('block');
+            expect(containerFixture.select('.britechart-tooltip').style('visibility')).not.toBe('hidden');
+            expect(containerFixture.select('.britechart-tooltip').style('visibility')).toBe('visible');
         });
 
         xit('should resize the tooltip depending of number of topics', () =>  {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Instead of applying the styles display: none and display: block, we need to change visibility attribute instead. The visual behavior remains the same but the tooltip DOM node remains in the chart and hence error is not being thrown.

## Motivation and Context
[NS_UPDATE javascript error in Firefox](https://github.com/eventbrite/britecharts-react/issues/75)

## How Has This Been Tested?
Revised the tests to test for visibility style attribute instead of display

## Screenshots (if appropriate):

![fix-firefox-tooltip](https://user-images.githubusercontent.com/282903/47155411-a63fa280-d2b2-11e8-8a03-03f31448be9c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [X] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
