### PR TITLE
Stacked area chart incorrect circle positions when > 10 areas

### DIFF
--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -1019,12 +1019,9 @@ define(function(require){
             cleanDataPointHighlights();
 
             // ensure order stays constant
-            let sortedValues = [];
-            values = values.filter(v => !!v);
-
-            for(let i = 0; i< order.length; i++){
-                sortedValues.push(values.find(o=> o.name === order[i]));
-            }
+            let sortedValues = order.reduce((acc, current) => {
+                return [...acc, values.find(({name}) => name === current)];
+            },[]);
 
             sortedValues.forEach((d, index) => {
                 let marker = verticalMarkerContainer

--- a/src/charts/stacked-area.js
+++ b/src/charts/stacked-area.js
@@ -1019,11 +1019,14 @@ define(function(require){
             cleanDataPointHighlights();
 
             // ensure order stays constant
-            values = values
-                .filter(v => !!v)
-                .sort((a,b) => order.indexOf(a.name) > order.indexOf(b.name));
+            let sortedValues = [];
+            values = values.filter(v => !!v);
 
-            values.forEach((d, index) => {
+            for(let i = 0; i< order.length; i++){
+                sortedValues.push(values.find(o=> o.name === order[i]));
+            }
+
+            sortedValues.forEach((d, index) => {
                 let marker = verticalMarkerContainer
                     .append('g')
                     .classed('circle-container', true)
@@ -1043,7 +1046,7 @@ define(function(require){
                             removeFilter(this);
                         });
 
-                accumulator = accumulator + values[index][valueLabel];
+                accumulator = accumulator + sortedValues[index][valueLabel];
 
                 marker.attr('transform', `translate( ${(- highlightCircleSize)}, ${(yScale(accumulator))} )` );
             });


### PR DESCRIPTION
## Description
fixing the sort algorithm to correctly transform the circle on hover over.

## Motivation and Context
Fixes this issue
https://github.com/eventbrite/britecharts/issues/682

## How Has This Been Tested?
Created sandbox and sample data and updated the code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
