### PR TITLE
Feature - last highlighted slice on mouse out transition

### DIFF
--- a/demos/src/demo-donut.js
+++ b/demos/src/demo-donut.js
@@ -36,7 +36,6 @@ function createDonutChart(optionalColorSchema) {
 
         donutChart
             .isAnimated(true)
-            .hasLastHoverSliceHighlighted(true)
             .highlightSliceById(2)
             .width(containerWidth)
             .height(containerWidth)

--- a/demos/src/demo-donut.js
+++ b/demos/src/demo-donut.js
@@ -36,6 +36,7 @@ function createDonutChart(optionalColorSchema) {
 
         donutChart
             .isAnimated(true)
+            .hasLastHoverSliceHighlighted(true)
             .highlightSliceById(2)
             .width(containerWidth)
             .height(containerWidth)

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -445,7 +445,7 @@ define(function(require) {
 
             // When there is a fixed highlighted slice,
             // we will always highlight it and render legend
-            if (highlightedSlice && hasFixedHighlightedSlice) {
+            if (highlightedSlice && hasFixedHighlightedSlice && !hasLastHoverSliceHighlighted) {
                 drawLegend(highlightedSlice.__data__);
                 tweenGrowth(highlightedSlice, externalRadius);
             }
@@ -671,6 +671,8 @@ define(function(require) {
          * If property is true, the last hovered slice will be highlighted
          * after 'mouseout` event is triggered. The last hovered slice will remain
          * in highlight state.
+         * Note: if both hasFixedHighlightedSlice and hasLastHoverSliceHighlighted
+         * are true, the latter property will override the former.
          * @param {boolean} _x          Decide whether the last hovered slice should be highlighted
          * @return {boolean | module}   Current hasLastHoverSliceHighlighted value or Chart module
          * @public

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -416,6 +416,8 @@ define(function(require) {
             drawLegend(d);
             dispatcher.call('customMouseOver', el, d, d3Selection.mouse(el), [chartWidth, chartHeight]);
 
+            // if the hovered slice is not the same as the last slice hovered
+            // after mouseout event, then shrink the last slice that was highlighted
             if (lastHighlightedSlice && el !== lastHighlightedSlice) {
                 tweenGrowth(lastHighlightedSlice, externalRadius - radiusHoverOffset, pieHoverTransitionDuration);
             }

--- a/src/charts/donut.js
+++ b/src/charts/donut.js
@@ -96,6 +96,9 @@ define(function(require) {
             highlightedSlice,
             hasFixedHighlightedSlice = false,
 
+            hasLastHoverSliceHighlighted = false,
+            lastHighlightedSlice = null,
+
             emptyDataConfig = {
                 emptySliceColor: '#EFF2F5',
                 showEmptySlice: false
@@ -413,6 +416,10 @@ define(function(require) {
             drawLegend(d);
             dispatcher.call('customMouseOver', el, d, d3Selection.mouse(el), [chartWidth, chartHeight]);
 
+            if (lastHighlightedSlice && el !== lastHighlightedSlice) {
+                tweenGrowth(lastHighlightedSlice, externalRadius - radiusHoverOffset, pieHoverTransitionDuration);
+            }
+
             if (highlightedSlice && el !== highlightedSlice) {
                 tweenGrowth(highlightedSlice, externalRadius - radiusHoverOffset);
             }
@@ -447,6 +454,12 @@ define(function(require) {
             // we will shrink the slice
             if (el !== highlightedSlice || (!hasFixedHighlightedSlice && el === highlightedSlice) ) {
                 tweenGrowth(el, externalRadius - radiusHoverOffset, pieHoverTransitionDuration);
+            }
+
+            if (hasLastHoverSliceHighlighted) {
+                drawLegend(el.__data__);
+                tweenGrowth(el, externalRadius);
+                lastHighlightedSlice = el;
             }
 
             dispatcher.call('customMouseOut', el, d, d3Selection.mouse(el), [chartWidth, chartHeight]);
@@ -640,8 +653,8 @@ define(function(require) {
          * Gets or Sets the hasFixedHighlightedSlice property of the chart, making it to
          * highlight the selected slice id set with `highlightSliceById` all the time.
          *
-         * @param  {Boolean} _x         If we want to make the highlighted slice permanently highlighted
-         * @return { Boolean | module}  Current hasFixedHighlightedSlice flag or Chart module
+         * @param  {boolean} _x         If we want to make the highlighted slice permanently highlighted
+         * @return {boolean | module}   Current hasFixedHighlightedSlice flag or Chart module
          * @public
          */
         exports.hasFixedHighlightedSlice = function(_x) {
@@ -652,6 +665,24 @@ define(function(require) {
 
             return this;
         };
+
+        /**
+         * Gets or sets the hasLastHoverSliceHighlighted property.
+         * If property is true, the last hovered slice will be highlighted
+         * after 'mouseout` event is triggered. The last hovered slice will remain
+         * in highlight state.
+         * @param {boolean} _x          Decide whether the last hovered slice should be highlighted
+         * @return {boolean | module}   Current hasLastHoverSliceHighlighted value or Chart module
+         * @public
+         */
+        exports.hasLastHoverSliceHighlighted = function(_x) {
+            if (!arguments.length) {
+                return hasLastHoverSliceHighlighted;
+            }
+            hasLastHoverSliceHighlighted = _x;
+
+            return this;
+        }
 
         /**
          * Gets or Sets the height of the chart

--- a/test/specs/donut.spec.js
+++ b/test/specs/donut.spec.js
@@ -504,10 +504,22 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                     expect(previous).not.toBe(expected);
                     expect(actual).toBe(expected);
                 });
+
+                it('should provide hasLastHoverSliceHighlighted getter and setter', () => {
+                    let previous = donutChart.hasLastHoverSliceHighlighted(),
+                        expected = true,
+                        actual;
+
+                    donutChart.hasLastHoverSliceHighlighted(expected);
+                    actual = donutChart.hasLastHoverSliceHighlighted();
+
+                    expect(previous).not.toBe(expected);
+                    expect(actual).toBe(expected);
+                });
             });
 
             describe('when margins are set partially', function() {
-            
+
                 it('should override the default values', () => {
                     let previous = donutChart.margin(),
                     expected = {
@@ -516,10 +528,10 @@ define(['d3', 'donut', 'donutChartDataBuilder'], function(d3, chart, dataBuilder
                         right: 20
                     },
                     actual;
-    
+
                     donutChart.width(expected);
                     actual = donutChart.width();
-    
+
                     expect(previous).not.toBe(actual);
                     expect(actual).toEqual(expected);
                 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added some additional logic for the new property `hasLastHoverSliceHighlighted`, which highlights the slice after `mouseout` event is called. *Note:* if donut char has both `hasFixedHighlightedSlice` and `hasLastHoverSliceHighlighted` as `true`, then `hasLastHoverSliceHighlighted` becomes the dominant factor. Otherwise, what's the point of setting it `true` (right?).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/eventbrite/britecharts/issues/692

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual tests:
![last_highlighted_slice](https://user-images.githubusercontent.com/9118852/50077359-0494de80-0199-11e9-9fec-9a2fef0add00.gif)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
