### PR TITLE
Add missing heatmap chart to the bundle

### DIFF
--- a/src/bundle.js
+++ b/src/bundle.js
@@ -9,6 +9,7 @@ import sparkline from './charts/sparkline.js';
 import stackedArea from './charts/stacked-area.js';
 import groupedBar from './charts/grouped-bar.js';
 import stackedBar from './charts/stacked-bar.js';
+import heatmap from './charts/heatmap.js';
 import step from './charts/step.js';
 import brush from './charts/brush.js';
 import colors from './charts/helpers/color.js';
@@ -25,6 +26,7 @@ export {
         stackedArea,
         groupedBar,
         stackedBar,
+        heatmap,
         step,
         brush,
         colors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For now, there is no way to use heatmap chart with bundled charts version. This commit adds missing heatmap to the dist.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change makes possible to call `britecharts.heatmap()` when using bundled charts version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've run tests and `yarn run build` to use distributive in development.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
