### PR TITLE
Feature - added rounding time interval to brush chart

### DIFF
--- a/src/charts/brush.js
+++ b/src/charts/brush.js
@@ -16,7 +16,7 @@ define(function(require) {
     const colorHelper = require('./helpers/color');
     const timeAxisHelper = require('./helpers/axis');
 
-    const {axisTimeCombinations} = require('./helpers/constants');
+    const {axisTimeCombinations, timeIntervals} = require('./helpers/constants');
 
     const {uniqueId} = require('./helpers/number');
     const {line} = require('./helpers/load');
@@ -109,6 +109,8 @@ define(function(require) {
 
             gradient = colorHelper.colorGradients.greenBlue,
             gradientId = uniqueId('brush-area-gradient'),
+
+            roundingTimeInterval = 'timeDay',
 
             // Dispatcher object to broadcast the mouse events
             // @see {@link https://github.com/d3/d3/blob/master/API.md#dispatches-d3-dispatch}
@@ -381,12 +383,12 @@ define(function(require) {
             if (selection) {
                 let dateExtent = selection.map(xScale.invert);
 
-                dateExtentRounded = dateExtent.map(d3Time.timeDay.round);
+                dateExtentRounded = dateExtent.map(timeIntervals[roundingTimeInterval].round);
 
                 // If empty when rounded, use floor & ceil instead.
                 if (dateExtentRounded[0] >= dateExtentRounded[1]) {
-                    dateExtentRounded[0] = d3Time.timeDay.floor(dateExtent[0]);
-                    dateExtentRounded[1] = d3Time.timeDay.offset(dateExtentRounded[0]);
+                    dateExtentRounded[0] = timeIntervals[roundingTimeInterval].floor(dateExtent[0]);
+                    dateExtentRounded[1] = timeIntervals[roundingTimeInterval].offset(dateExtentRounded[0]);
                 }
 
                 d3Selection.select(this)
@@ -626,6 +628,25 @@ define(function(require) {
               return xTicks;
             }
             xTicks = _x;
+
+            return this;
+        };
+
+        /**
+         * Gets or Sets the rounding time interval of the selection boundary
+         * @param  {roundingTimeInterval} _x Desired time interval for the selection, default 'timeDay'. All options are:
+         * timeMillisecond, utcMillisecond, timeSecond, utcSecond, timeMinute, utcMinute, timeHour, utcHour, timeDay, utcDay
+         * timeWeek, utcWeek, timeSunday, utcSunday, timeMonday, utcMonday, timeTuesday, utcTuesday, timeWednesday,
+         * utcWednesday, timeThursday, utcThursday, timeFriday, utcFriday, timeSaturday, utcSaturday, timeMonth, utcMonth,
+         * timeYear and utcYear. Visit https://github.com/d3/d3-time#intervals for more information.
+         * @return { (roundingTimeInterval | Module) } Current time interval or module to chain calls
+         * @public
+         */
+        exports.roundingTimeInterval = function(_x) {
+            if (!arguments.length) {
+                return roundingTimeInterval;
+            }
+            roundingTimeInterval = _x;
 
             return this;
         };

--- a/src/charts/helpers/constants.js
+++ b/src/charts/helpers/constants.js
@@ -1,6 +1,7 @@
 define(function() {
 
     const d3Shape = require('d3-shape');
+    const d3Time = require('d3-time');
 
     const axisTimeCombinations = {
         MINUTE_HOUR: 'minute-hour',
@@ -34,12 +35,46 @@ define(function() {
         'percentage': 100
     }];
 
+    const timeIntervals = {
+        timeMillisecond: d3Time.timeMillisecond,
+        utcMillisecond: d3Time.utcMillisecond,
+        timeSecond: d3Time.timeSecond ,
+        utcSecond: d3Time.utcSecond,
+        timeMinute: d3Time.timeMinute,
+        utcMinute: d3Time.utcMinute,
+        timeHour: d3Time.timeHour,
+        utcHour: d3Time.utcHour,
+        timeDay: d3Time.timeDay,
+        utcDay: d3Time.utcDay,
+        timeWeek: d3Time.timeWeek,
+        utcWeek: d3Time.utcWeek,
+        timeSunday: d3Time.timeSunday,
+        utcSunday: d3Time.utcSunday,
+        timeMonday: d3Time.timeMonday,
+        utcMonday: d3Time.utcMonday,
+        timeTuesday: d3Time.timeTuesday,
+        utcTuesday: d3Time.utcTuesday,
+        timeWednesday: d3Time.timeWednesday,
+        utcWednesday: d3Time.utcWednesday,
+        timeThursday: d3Time.timeThursday,
+        utcThursday: d3Time.utcThursday,
+        timeFriday: d3Time.timeFriday,
+        utcFriday: d3Time.utcFriday,
+        timeSaturday: d3Time.timeSaturday,
+        utcSaturday: d3Time.utcSaturday,
+        timeMonth: d3Time.timeMonth,
+        utcMonth: d3Time.utcMonth,
+        timeYear: d3Time.timeYear,
+        utcYear: d3Time.utcYear
+    };
+
     return {
         axisTimeCombinations,
         curveMap,
         emptyDonutData,
         timeBenchmarks,
-        lineGradientId: 'lineGradientId'
+        lineGradientId: 'lineGradientId',
+        timeIntervals
     };
 });
 

--- a/test/specs/brush.spec.js
+++ b/test/specs/brush.spec.js
@@ -197,6 +197,18 @@ define(['jquery', 'd3', 'brush', 'brushChartDataBuilder'], function($, d3, chart
                 expect(previous).not.toBe(expected);
                 expect(actual).toBe(expected);
             });
+
+            it('should provide a roundingTimeInterval getter and setter', () => {
+                let previous = brushChart.roundingTimeInterval(),
+                    expected = 'timeMillisecond',
+                    actual;
+
+                brushChart.roundingTimeInterval(expected);
+                actual = brushChart.roundingTimeInterval();
+
+                expect(previous).not.toBe(expected);
+                expect(actual).toBe(expected);
+            });
         });
     });
 });


### PR DESCRIPTION
https://github.com/eventbrite/britecharts/issues/701

## Description
I would like to be able to customise the rounding of dateExtentRounded in the brush charts handleBrushEnd event. Rounding to the nearest day as only option does not fulfil many use cases for us.

## Motivation and Context
I have graphs with lots of sample values within a day so only being able to select a day makes this of little worth. Adding custom rounding allows me to choose with rounding I want.

## How Has This Been Tested?
Unit tests (added) and sandboxed (local).

## Types of changes
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the [code style guide](https://github.com/eventbrite/britecharts/blob/master/CODESTYLEGUIDE.md) of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
