### PR TITLE
Allowing no quantities and adding demo on donut page

### DIFF
--- a/demos/donut.html
+++ b/demos/donut.html
@@ -92,6 +92,7 @@ donutContainer.datum(dataset).call(donutChart);
                 <article>
                     <h2>Donut Chart with fixed highlighted slice</h2>
                     <div class="js-donut-highlight-slice-chart-container card--chart"></div>
+                    <div class="js-vertical-legend-no-quantity-container"></div>
                 </article>
             </section>
         </div>
@@ -100,14 +101,21 @@ col-md-6 sidebar">
             <h3>The code</h3>
             <pre><code class="language-javascript">
 donutChart
-    .highlightSliceById(1)
+    .highlightSliceById(11)
     .hasFixedHighlightedSlice(true)
     .width(containerWidth)
     .height(containerWidth/1.8)
     .externalRadius(containerWidth/5)
-    .internalRadius(containerWidth/10);
+    .internalRadius(containerWidth/10)
+    .on('customMouseOver', function (data) {
+        legendChart.highlight(data.data.id);
+    })
+    .on('customMouseOut', function () {
+        legendChart.highlight(11);
+    });
 
-    donutContainer.datum(dataset).call(donutChart);
+legendChart.highlight(11);
+donutContainer.datum(datasetWithThreeItems).call(donutChart);
             </code></pre>
 
             <h4>Demo Code</h4>

--- a/demos/src/demo-donut.js
+++ b/demos/src/demo-donut.js
@@ -107,6 +107,28 @@ function getInlineLegendChart(dataset, optionalColorSchema) {
     }
 }
 
+function getVerticalLegendChart(dataset, optionalColorSchema) {
+    let legendChart = legend(),
+        legendContainer = d3Selection.select('.js-vertical-legend-no-quantity-container'),
+        containerWidth = legendContainer.node() ? legendContainer.node().getBoundingClientRect().width : false;
+
+    if (containerWidth) {
+        d3Selection.select('.js-vertical-legend-no-quantity-container .britechart-legend').remove();
+
+        legendChart
+            .width(containerWidth)
+            .height(100);
+
+        if (optionalColorSchema) {
+            legendChart.colorSchema(optionalColorSchema);
+        }
+
+        legendContainer.datum(dataset).call(legendChart);
+
+        return legendChart;
+    }
+}
+
 function createSmallDonutChart() {
     let donutChart = donut(),
         donutContainer = d3Selection.select('.js-small-donut-chart-container'),
@@ -131,7 +153,14 @@ function createSmallDonutChart() {
 }
 
 function createDonutWithHighlightSliceChart() {
-    let donutChart = donut(),
+    let dataNoQuantity = JSON.parse(JSON.stringify(datasetWithThreeItems))
+        .map((item) => {
+            delete item.quantity;
+
+            return item;
+        }),
+        legendChart = getVerticalLegendChart(dataNoQuantity),
+        donutChart = donut(),
         donutContainer = d3Selection.select('.js-donut-highlight-slice-chart-container'),
         containerWidth = donutContainer.node() ? donutContainer.node().getBoundingClientRect().width : false;
 
@@ -142,8 +171,15 @@ function createDonutWithHighlightSliceChart() {
             .width(containerWidth)
             .height(containerWidth/1.8)
             .externalRadius(containerWidth/5)
-            .internalRadius(containerWidth/10);
+            .internalRadius(containerWidth/10)
+            .on('customMouseOver', function (data) {
+                legendChart.highlight(data.data.id);
+            })
+            .on('customMouseOut', function () {
+                legendChart.highlight(11);
+            });
 
+        legendChart.highlight(11);
         donutContainer.datum(datasetWithThreeItems).call(donutChart);
     }
 }

--- a/demos/src/demo-donut.js
+++ b/demos/src/demo-donut.js
@@ -172,8 +172,8 @@ function createDonutWithHighlightSliceChart() {
             .height(containerWidth/1.8)
             .externalRadius(containerWidth/5)
             .internalRadius(containerWidth/10)
-            .on('customMouseOver', function (data) {
-                legendChart.highlight(data.data.id);
+            .on('customMouseOver', function (slice) {
+                legendChart.highlight(slice.data.id);
             })
             .on('customMouseOut', function () {
                 legendChart.highlight(11);

--- a/src/charts/legend.js
+++ b/src/charts/legend.js
@@ -13,8 +13,8 @@ define(function(require){
      * @typedef LegendChartData
      * @type {Object[]}
      * @property {Number} id        Id of the group (required)
-     * @property {Number} quantity  Quantity of the group (required)
      * @property {String} name      Name of the group (required)
+     * @property {Number} quantity  Quantity of the group (optional)
      *
      * @example
      * [
@@ -90,6 +90,7 @@ define(function(require){
             isFadedClassName = 'is-faded',
             isHorizontal = false,
             highlightedEntryId = null,
+            hasQuantities = true,
 
             // colors
             colorScale,
@@ -100,6 +101,7 @@ define(function(require){
 
             getFormattedQuantity = ({quantity}) => d3Format.format(numberFormat)(quantity) + unit,
             getCircleFill = ({name}) => colorScale(name),
+            hasQuantity = ({quantity}) => typeof quantity === 'number' || typeof quantity === 'string',
 
             entries,
             chartWidth, chartHeight,
@@ -117,7 +119,7 @@ define(function(require){
             _selection.each(function(_data){
                 chartWidth = width - margin.left - margin.right;
                 chartHeight = height - margin.top - margin.bottom;
-                data = _data;
+                data = cleanData(_data);
 
                 buildColorScale();
                 buildSVG(this);
@@ -149,7 +151,7 @@ define(function(require){
                 splitInLines();
             }
 
-            centerLegendOnSVG();
+            centerInlineLegendOnSVG();
         }
 
         /**
@@ -202,14 +204,51 @@ define(function(require){
          * @return {void}
          * @private
          */
-        function centerLegendOnSVG() {
+        function centerInlineLegendOnSVG() {
             let legendGroupSize = svg.select('g.legend-container-group').node().getBoundingClientRect().width + getLineElementMargin();
             let emptySpace = width - legendGroupSize;
+            let newXPosition = (emptySpace/2);
 
             if (emptySpace > 0) {
                 svg.select('g.legend-container-group')
-                    .attr('transform', `translate(${emptySpace/2},0)`)
+                    .attr('transform', `translate(${newXPosition},0)`)
             }
+        }
+
+        /**
+         * Centers the legend on the chart given that is a stack of labels
+         * @return {void}
+         * @private
+         */
+        function centerVerticalLegendOnSVG() {
+            let legendGroupSize = svg.select('g.legend-container-group').node().getBoundingClientRect().width;
+            let emptySpace = width - legendGroupSize;
+            let newXPosition = (emptySpace / 2) - (legendGroupSize / 2);
+
+            if (emptySpace > 0) {
+                svg.select('g.legend-container-group')
+                    .attr('transform', `translate(${newXPosition},0)`)
+            }
+        }
+
+        /**
+         * Makes sure the types of the data are right and checks if it has quantities
+         * @param {LegendChartData} data
+         * @private
+         */
+        function cleanData(data) {
+            hasQuantities = data.filter(hasQuantity).length === data.length;
+
+            return data
+                .reduce((acc, d) => {
+                    if (d.quantity !== undefined) {
+                        d.quantity = +d.quantity;
+                    }
+                    d.name = String(d.name);
+                    d.id = +d.id;
+
+                    return [...acc, d];
+                }, []);
         }
 
         /**
@@ -333,17 +372,21 @@ define(function(require){
                 .style('font-size', `${textSize}px`)
                 .style('letter-spacing', `${textLetterSpacing}px`);
 
-            svg.select('.legend-group')
-                .selectAll('g.legend-line')
-                .selectAll('g.legend-entry')
-              .append('text')
-                .classed('legend-entry-value', true)
-                .text(getFormattedQuantity)
-                .attr('x', chartWidth - valueReservedSpace)
-                .style('font-size', `${textSize}px`)
-                .style('letter-spacing', `${numberLetterSpacing}px`)
-                .style('text-anchor', 'end')
-                .style('startOffset', '100%');
+            if (hasQuantities) {
+                svg.select('.legend-group')
+                    .selectAll('g.legend-line')
+                    .selectAll('g.legend-entry')
+                  .append('text')
+                    .classed('legend-entry-value', true)
+                    .text(getFormattedQuantity)
+                    .attr('x', chartWidth - valueReservedSpace)
+                    .style('font-size', `${textSize}px`)
+                    .style('letter-spacing', `${numberLetterSpacing}px`)
+                    .style('text-anchor', 'end')
+                    .style('startOffset', '100%');
+            } else {
+                centerVerticalLegendOnSVG();
+            }
 
             // Exit
             svg.select('.legend-group')

--- a/src/charts/legend.js
+++ b/src/charts/legend.js
@@ -241,7 +241,7 @@ define(function(require){
 
             return data
                 .reduce((acc, d) => {
-                    if (d.quantity !== undefined) {
+                    if (d.quantity !== undefined && d.quantity !== null) {
                         d.quantity = +d.quantity;
                     }
                     d.name = String(d.name);
@@ -373,17 +373,7 @@ define(function(require){
                 .style('letter-spacing', `${textLetterSpacing}px`);
 
             if (hasQuantities) {
-                svg.select('.legend-group')
-                    .selectAll('g.legend-line')
-                    .selectAll('g.legend-entry')
-                  .append('text')
-                    .classed('legend-entry-value', true)
-                    .text(getFormattedQuantity)
-                    .attr('x', chartWidth - valueReservedSpace)
-                    .style('font-size', `${textSize}px`)
-                    .style('letter-spacing', `${numberLetterSpacing}px`)
-                    .style('text-anchor', 'end')
-                    .style('startOffset', '100%');
+                writeEntryValues();
             } else {
                 centerVerticalLegendOnSVG();
             }
@@ -441,6 +431,25 @@ define(function(require){
 
             lastEntry.attr('transform', `translate(${markerSize},0)`);
             newLine.append(() => lastEntry.node());
+        }
+
+        /**
+         * Draws the data entry quantities within the legend-entry lines
+         * @return {void}
+         * @private
+         */
+        function writeEntryValues() {
+            svg.select('.legend-group')
+                .selectAll('g.legend-line')
+                .selectAll('g.legend-entry')
+              .append('text')
+                .classed('legend-entry-value', true)
+                .text(getFormattedQuantity)
+                .attr('x', chartWidth - valueReservedSpace)
+                .style('font-size', `${textSize}px`)
+                .style('letter-spacing', `${numberLetterSpacing}px`)
+                .style('text-anchor', 'end')
+                .style('startOffset', '100%');
         }
 
         // API

--- a/test/fixtures/donutChartDataBuilder.js
+++ b/test/fixtures/donutChartDataBuilder.js
@@ -3,6 +3,7 @@ define(function(require) {
 
     var _ = require('underscore'),
 
+        jsonLegendNoQuantity = require('json-loader!../json/legendDataNoQuantity.json'),
         jsonFivePlusOther = require('json-loader!../json/donutDataFivePlusOther.json'),
         jsonFivePlusOtherNoPercent = require('json-loader!../json/donutDataFivePlusOtherNoPercent.json'),
         jsonOneZeroed = require('json-loader!../json/donutDataOneZeroed.json'),
@@ -39,9 +40,14 @@ define(function(require) {
             return new this.Klass(attributes);
         };
 
-
         this.withAllTopicsAtZero = function() {
             var attributes = _.extend({}, this.config, jsonAllZeroed);
+
+            return new this.Klass(attributes);
+        };
+
+        this.withNoQuantity = function() {
+            var attributes = _.extend({}, this.config, jsonLegendNoQuantity);
 
             return new this.Klass(attributes);
         };

--- a/test/json/legendDataNoQuantity.json
+++ b/test/json/legendDataNoQuantity.json
@@ -1,0 +1,16 @@
+{
+    "data": [
+        {
+            "name": "Shiny",
+            "id": 11
+        },
+        {
+            "name": "Radiant",
+            "id": 12
+        },
+        {
+            "name": "Sparkling",
+            "id": 13
+        }
+    ]
+}

--- a/test/specs/legend.spec.js
+++ b/test/specs/legend.spec.js
@@ -112,6 +112,31 @@ define(['d3', 'legend', 'donutChartDataBuilder'], function(d3, legend, dataBuild
                 });
             });
 
+            describe('when no quantities in our data', () => {
+                beforeEach(() => {
+                    dataset = aTestDataSet()
+                        .withNoQuantity()
+                        .build();
+
+                    containerFixture = d3.select('.test-container');
+                    containerFixture.datum(dataset).call(legendChart);
+                });
+
+                it('should render the legend', () => {
+                    const expected = false;
+                    const actual = containerFixture.select('svg.britechart-legend').empty();
+
+                    expect(actual).toEqual(expected);
+                });
+
+                it('should not draw any value', () => {
+                    const expected = 0;
+                    const actual = containerFixture.selectAll('.legend-entry-value').nodes().length;
+
+                    expect(actual).toEqual(expected);
+                });
+            });
+
             describe('API', function() {
 
                 it('should provide margin getter and setter', () =>{
@@ -200,8 +225,8 @@ define(['d3', 'legend', 'donutChartDataBuilder'], function(d3, legend, dataBuild
 
                 it('should provide a highlight function', () => {
                     let lines = containerFixture
-                    .select('.britechart-legend')
-                    .selectAll('.legend-entry'),
+                        .select('.britechart-legend')
+                        .selectAll('.legend-entry'),
                     elements = lines.nodes();
 
                     legendChart.highlight(dataset[0].id);
@@ -268,7 +293,7 @@ define(['d3', 'legend', 'donutChartDataBuilder'], function(d3, legend, dataBuild
         });
 
         describe('when margins are set partially', function() {
-            
+
             it('should override the default values', () => {
                 let previous = legendChart.margin(),
                 expected = {
@@ -284,7 +309,7 @@ define(['d3', 'legend', 'donutChartDataBuilder'], function(d3, legend, dataBuild
                 expect(previous).not.toBe(actual);
                 expect(actual).toEqual(expected);
             })
-        });  
+        });
 
         describe('when legend is horizontal', () => {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the possibility of rendering a vertical legend without quantities
Also added demo in the donut chart demo page

## Motivation and Context
Sometimes we just want to show a legend in a vertical format with names and colors. This is especially useful for time series charts

## How Has This Been Tested?
Added new data and tests

## Screenshots (if appropriate):
![Tutorial__Donut_Chart](https://user-images.githubusercontent.com/190833/56452729-bf6cee80-62e9-11e9-99dd-aa092b3f2a52.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

