### PR TITLE
Add support for null data point in line chart #258

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -34,6 +34,7 @@ define(function(require){
         uniqueId
     } = require('./helpers/number');
 
+    const acceptNullValue = (value) => value === null ? null : +value;
     /**
      * @typedef D3Selection
      * @type {Array[]}
@@ -596,10 +597,12 @@ define(function(require){
             const normalizedDataByTopic = dataByTopic.reduce((accum, topic) => {
                 let {dates, ...restProps} = topic;
 
-                let newDates = dates.map(d => ({
-                       date: new Date(d[dateLabel]),
-                       value: +d[valueLabel]
-                }));
+                let newDates = dates.map(d => {
+                    return {
+                        date: new Date(d[dateLabel]),
+                        value: acceptNullValue(d[valueLabel])
+                    };
+                });
 
                 accum.push({ dates: newDates, ...restProps });
 
@@ -711,6 +714,7 @@ define(function(require){
             topicLine = d3Shape.line()
                 .curve(curveMap[lineCurve])
                 .x(({date}) => xScale(date))
+                .defined(({value}) => value !== null)
                 .y(({value}) => yScale(value));
 
             lines = svg.select('.chart-group').selectAll('.line')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
nulls are now handles correctly extending the time axis but not being drawn as point in the graph.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
tested this change in my production environment handling null values

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/366321/60871340-3657ba80-a23b-11e9-80a6-cf1b4710ed79.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Review the list before submitting your pull request -->
<!--- Leave the list intact for the code reviewer's use -->
- [ ] Latest master code has been merged into this branch
- [ ] No commented out code (if required, place // TODO above with explanation)
- [ ] No linting issues
- [ ] Build is successful
- [ ] Code follows the [API Guidelines](http://eventbrite.github.io/britecharts/topics-index.html#toc5__anchor)
- [ ] Updated the documentation
- [ ] Added tests to cover changes
- [ ] All new and existing tests passed