### PR TITLE
Clear tooltip cache before path is redrawn

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -706,6 +706,9 @@ export default function module() {
         let lines,
             topicLine;
 
+        // clear tooltip chache on path redraw
+        pathYCache = {};
+
         topicLine = line()
             .curve(curveMap[lineCurve])
             .x(({date}) => xScale(date))


### PR DESCRIPTION
Before if the path was updated, the tooltip point would be placed  in the wrong location according to the cache.
This change reset the cache before drawing the line.
