### PR TITLE
Feature: added ability to customize days labels

### DIFF
--- a/src/charts/heatmap.js
+++ b/src/charts/heatmap.js
@@ -76,6 +76,8 @@ export default function module() {
 
         animationDuration = 2000,
 
+        yAxisLabels,
+
         dayLabels,
         daysHuman = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
         dayLabelWidth = 30,
@@ -214,10 +216,11 @@ export default function module() {
      * Draws the day labels
      */
     function drawDayLabels() {
-        let dayLabelsGroup = svg.select('.day-labels-group');
+        const dayLabelsGroup = svg.select('.day-labels-group');
+        const arrayForYAxisLabels = yAxisLabels || daysHuman;
 
         dayLabels = svg.select('.day-labels-group').selectAll('.day-label')
-            .data(daysHuman);
+            .data(arrayForYAxisLabels);
 
         dayLabels.enter()
             .append('text')
@@ -226,7 +229,7 @@ export default function module() {
             .attr('y', (d, i) => i * boxSize)
             .style('text-anchor', 'start')
             .style('dominant-baseline', 'central')
-            .attr('class', 'day-label');
+            .attr('class', 'day-label y-axis-label');
 
         dayLabelsGroup.attr('transform', `translate(-${dayLabelWidth}, ${boxSize / 2})`);
     }
@@ -322,6 +325,21 @@ export default function module() {
             ...margin,
             ..._x
         };
+
+        return this;
+    };
+
+    /**
+     * Gets or Sets the y-axis labels of the chart
+     * @param  {String[]} _x            An array of string labels across the y-axis
+     * @return {yAxisLabels | module}   Current yAxisLabels array or Chart module to chain calls
+     * @public
+     */
+    exports.yAxisLabels = function (_x) {
+        if (!arguments.length) {
+            return yAxisLabels;
+        }
+        yAxisLabels = _x;
 
         return this;
     };

--- a/test/specs/heatmap.spec.js
+++ b/test/specs/heatmap.spec.js
@@ -117,6 +117,26 @@ describe('Heatmap Chart', () => {
         });
     });
 
+    describe('custom axis labels', () => {
+
+        it('should render custom y axis labels correctly', () => {
+            const customYAxisLabels = ['Test1', 'Test2'];
+
+            // clear container to avoid having multiple
+            //  charts within one container
+            containerFixture.html('');
+            containerFixture.datum(dataset).call(heatmapChart);
+            heatmapChart.yAxisLabels(customYAxisLabels);
+
+            const yAxisLabels = containerFixture.select('svg')
+                .selectAll('.heatmap .y-axis-label');
+
+            yAxisLabels.each((yAxisLabel, i) => {
+                expect(yAxisLabel).toBe(customYAxisLabels[i]);
+            });
+        });
+    });
+
     describe('API', () => {
 
         it('should provide boxSize getter and setter', () => {
@@ -190,6 +210,18 @@ describe('Heatmap Chart', () => {
 
             heatmapChart.width(expected);
             actual = heatmapChart.width();
+
+            expect(previous).not.toBe(actual);
+            expect(actual).toBe(expected);
+        });
+
+        it('should provide yAxisLabels getter and setter', () => {
+            let previous = heatmapChart.yAxisLabels(),
+                expected = ['One', 'Two', 'Three'],
+                actual;
+
+            heatmapChart.yAxisLabels(expected);
+            actual = heatmapChart.yAxisLabels();
 
             expect(previous).not.toBe(actual);
             expect(actual).toBe(expected);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses some of the comments on this one https://github.com/eventbrite/britecharts/issues/763. Allow users to add custom `y-axis` labels, specifically labels for days. If it's not given, then display days labels by default.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/eventbrite/britecharts/issues/763

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for render and API

## Screenshots (if appropriate):

<img width="948" alt="Screen Shot 2019-11-19 at 8 37 50 PM" src="https://user-images.githubusercontent.com/9118852/69206731-76994480-0b1b-11ea-8e57-cfa07eb05a45.png">

**NOTE**: Check list seems redundant.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactor (changes the way we code something without changing its functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Review the list before submitting your pull request -->
<!--- Leave the list intact for the code reviewer's use -->
- [x] Latest master code has been merged into this branch
- [x] No commented out code (if required, place // TODO above with explanation)
- [x] No linting issues
- [x] Build is successful
- [x] Code follows the [API Guidelines](http://eventbrite.github.io/britecharts/topics-index.html#toc5__anchor)
- [x] Updated the documentation
- [x] Added tests to cover changes
- [x] All new and existing tests passed